### PR TITLE
Fix Codex auth JSON path shape

### DIFF
--- a/fastllm/acomplete.py
+++ b/fastllm/acomplete.py
@@ -29,7 +29,7 @@ oai_spec  = SpecParser.from_openapi(dict2obj(json.loads((specs_path/'openai.with
 gem_spec  = SpecParser.from_discovery(dict2obj(json.loads((specs_path/'gemini.json').read_text())))
 
 # %% ../nbs/06_acomplete.ipynb #32ee2546
-_codex_json = '~/.codex/auth.json', 'tokens','access_token'
+_codex_json = '~/.codex/auth.json', ('tokens','access_token')
 vendor_mapping = {
     "openai":       ('openai', 'https://api.openai.com/v1', 'OPENAI_API_KEY'),
     "anthropic":    ('anthropic', 'https://api.anthropic.com', 'ANTHROPIC_API_KEY'),

--- a/nbs/06_acomplete.ipynb
+++ b/nbs/06_acomplete.ipynb
@@ -167,7 +167,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "_codex_json = '~/.codex/auth.json', 'tokens','access_token'\n",
+    "_codex_json = '~/.codex/auth.json', ('tokens','access_token')\n",
     "vendor_mapping = {\n",
     "    \"openai\":       ('openai', 'https://api.openai.com/v1', 'OPENAI_API_KEY'),\n",
     "    \"anthropic\":    ('anthropic', 'https://api.anthropic.com', 'ANTHROPIC_API_KEY'),\n",


### PR DESCRIPTION
mk_client expects auth metadata as (filename, keys), where keys is passed to nested_idx with *keys. Codex used a flat tuple, so fn, keys failed unless CODEX_AUTH_TOKEN was set. Store the JSON path as a tuple.