### PR TITLE
force enable web_search for codex models

### DIFF
--- a/fastllm/types.py
+++ b/fastllm/types.py
@@ -326,7 +326,7 @@ codex_pricing = dict(
     cache_creation_input_token_cost = 0.10/1_000_000, cache_read_input_token_cost = 0.10/1_000_000)
 
 for model in (codex54, codex54m, codex55):
-    register_model_info(model, 'codex', base=model, base_vendor_name='chatgpt', **codex_pricing)
+    register_model_info(model, 'codex', base=model, base_vendor_name='chatgpt', supports_web_search=True, **codex_pricing)
 
 register_model_info(codex53spark, 'codex', **codex_pricing,
     supports_vision=False, supports_image_input=False, supports_web_search=True, supports_reasoning=True,

--- a/nbs/00_types.ipynb
+++ b/nbs/00_types.ipynb
@@ -1057,7 +1057,7 @@
     "    cache_creation_input_token_cost = 0.10/1_000_000, cache_read_input_token_cost = 0.10/1_000_000)\n",
     "\n",
     "for model in (codex54, codex54m, codex55):\n",
-    "    register_model_info(model, 'codex', base=model, base_vendor_name='chatgpt', **codex_pricing)\n",
+    "    register_model_info(model, 'codex', base=model, base_vendor_name='chatgpt', supports_web_search=True, **codex_pricing)\n",
     "\n",
     "register_model_info(codex53spark, 'codex', **codex_pricing,\n",
     "    supports_vision=False, supports_image_input=False, supports_web_search=True, supports_reasoning=True,\n",


### PR DESCRIPTION
The litellm metadata file is missing `supports_web_search` for GPT-5.4 so the Codex version wasn't getting it. Explicitly set it to True like we do for non-codex gpt models.