### PR TITLE
yield server tools mid-stream

### DIFF
--- a/fastllm/streaming.py
+++ b/fastllm/streaming.py
@@ -99,20 +99,24 @@ async def mk_acollect_stream(it, index_fn, model=None, api_name=None, vendor_nam
     "Collect a Delta stream, yielding incremental chunks and a final Completion."
     part_accum,deltas,stop_callables = PartAccum(), [], L(stop_callables)
     fin, usg, typ, last_typ, last_idx = [None]*5
+    srv_tcs,srv_yielded = {},set()
     def _fidx(d, name, pt=None):
         nonlocal typ, last_idx
         typ = getattr(PartType, pt or name)
         idx,last_idx = index_fn(d, typ, last_typ, last_idx)
         return idx
     def _proc(d, name, pt=None, kw='txt', ret=None):
-        if not ret and not (val := getattr(d, name)): return
+        if not ret and not (val := getattr(d, name)): return None, None
         idx = _fidx(d, name, pt)
         part_accum.append(typ, idx, **(ret or {kw: val}))
-        return ret or {name: val}
+        return ret or {name: val}, part_accum.parts[idx]
     def _yield_parts(d):
         for args in [('text',), ('thinking',), ('citations', 'text', 'citations')]:
-            if (r := _proc(d, args[0], pt=args[1] if len(args)>1 else None, kw=args[2] if len(args)>2 else 'txt')):
-                yield r
+            r,_ = _proc(d, args[0], pt=args[1] if len(args)>1 else None, kw=args[2] if len(args)>2 else 'txt')
+            if r: yield r
+    def _yield_srv(tid):
+        srv_yielded.add(tid)
+        return srv_tcs[tid]
     stop, stop_yielded = False, False
     async for d in it:
         # Check stop condition and yield stop delta
@@ -127,17 +131,30 @@ async def mk_acollect_stream(it, index_fn, model=None, api_name=None, vendor_nam
         # Rest incl. tools, finish reason, usage is processed independently
         for tc in d.tool_calls:
             args = tc.arguments.get('_delta', tc.arguments)
-            _proc(d, 'tool_use', ret=dict(id=tc.id, name=tc.name, arguments=args, server=tc.server, extra=tc.extra))
+            _,part = _proc(d, 'tool_use', ret=dict(id=tc.id, name=tc.name, arguments=args, server=tc.server, extra=tc.extra))
+            # Stream complete server tool calls immediately
+            if tc.server and tc.id and tc.name:
+                srv_tcs[tc.id] = part
+                if tc.arguments and isinstance(tc.arguments, dict) and '_delta' not in tc.arguments and tc.id not in srv_yielded:
+                    yield _yield_srv(tc.id)
         if d.server_tool_result:
             idx = _fidx(d, 'server_tool_result')
             part_accum.parts[idx] = Part(type=typ, data=d.server_tool_result)
-        if (r:=_proc(d, 'refusal')): yield r
+            tid = d.server_tool_result.get('tool_use_id')
+            # Avoid duplicating tool calls already yielded during streaming
+            if (acc:=srv_tcs.get(tid)) and tid not in srv_yielded:
+                if isinstance(acc.arguments, str):
+                    try: acc.arguments = json.loads(acc.arguments) if acc.arguments else {}
+                    except json.JSONDecodeError: pass
+                yield _yield_srv(tid)
+        r,_ = _proc(d, 'refusal')
+        if r: yield r
         if d.finish_reason: fin = d.finish_reason
         if d.usage: usg = d.usage
         last_typ = typ
         deltas.append(d)
     part_accum.finalize()
-    tcs = part_accum.tool_calls
+    tcs = [t for t in part_accum.tool_calls if not (t.server and t.id in srv_yielded)]
     if api_name: usg = api_registry.apis[api_name].finalize_usage(usg, part_accum.parts)
     if stop: fin = FinishReason.stop
     fin = FinishReason.tool_calls if fin==FinishReason.stop and any(~L(tcs).attrgot('server')) else fin # recheck tool calls post collation
@@ -146,4 +163,3 @@ async def mk_acollect_stream(it, index_fn, model=None, api_name=None, vendor_nam
             message=Msg(role="assistant", content=part_accum.parts),
             finish_reason=fin, usage=usg, tool_calls=tcs, api_name=api_name, vendor_name=vendor_name,
             raw={'deltas':deltas})
-

--- a/fastllm/types.py
+++ b/fastllm/types.py
@@ -223,9 +223,8 @@ def payload_kwargs(msgs, model, stream=False, system=None, max_tokens=None, temp
 
 # %% ../nbs/00_types.ipynb #c2a2cb49
 def get_api_key(api_key, default):
-    err = ValueError(f"Missing API key: make sure to have the expected env var name or pass `api_key`")
     key = api_key or os.getenv(default)
-    if not key: raise err
+    if not key: raise ValueError(f"Missing API key: set environment variable '{default}' or pass `api_key` parameter")
     return key
 
 # %% ../nbs/00_types.ipynb #852adecd

--- a/nbs/00_types.ipynb
+++ b/nbs/00_types.ipynb
@@ -897,9 +897,8 @@
    "source": [
     "#| export\n",
     "def get_api_key(api_key, default):\n",
-    "    err = ValueError(f\"Missing API key: make sure to have the expected env var name or pass `api_key`\")\n",
     "    key = api_key or os.getenv(default)\n",
-    "    if not key: raise err\n",
+    "    if not key: raise ValueError(f\"Missing API key: set environment variable '{default}' or pass `api_key` parameter\")\n",
     "    return key"
    ]
   },

--- a/nbs/01_streaming.ipynb
+++ b/nbs/01_streaming.ipynb
@@ -308,7 +308,7 @@
     "    max_print = 10\n",
     "    cnt = 0\n",
     "    def print_stream(self,o):\n",
-    "        if not isinstance(o, Completion): \n",
+    "        if not isinstance(o, (Completion, ToolCall)): \n",
     "            if o.get('thinking') and self.cnt<self.max_print: print('🧠',end='',flush=True)\n",
     "            if (txt:=o.get('text')): print(txt,end='',flush=True)\n",
     "            self.cnt+=1\n",
@@ -770,20 +770,24 @@
     "    \"Collect a Delta stream, yielding incremental chunks and a final Completion.\"\n",
     "    part_accum,deltas,stop_callables = PartAccum(), [], L(stop_callables)\n",
     "    fin, usg, typ, last_typ, last_idx = [None]*5\n",
+    "    srv_tcs,srv_yielded = {},set()\n",
     "    def _fidx(d, name, pt=None):\n",
     "        nonlocal typ, last_idx\n",
     "        typ = getattr(PartType, pt or name)\n",
     "        idx,last_idx = index_fn(d, typ, last_typ, last_idx)\n",
     "        return idx\n",
     "    def _proc(d, name, pt=None, kw='txt', ret=None):\n",
-    "        if not ret and not (val := getattr(d, name)): return\n",
+    "        if not ret and not (val := getattr(d, name)): return None, None\n",
     "        idx = _fidx(d, name, pt)\n",
     "        part_accum.append(typ, idx, **(ret or {kw: val}))\n",
-    "        return ret or {name: val}\n",
+    "        return ret or {name: val}, part_accum.parts[idx]\n",
     "    def _yield_parts(d):\n",
     "        for args in [('text',), ('thinking',), ('citations', 'text', 'citations')]:\n",
-    "            if (r := _proc(d, args[0], pt=args[1] if len(args)>1 else None, kw=args[2] if len(args)>2 else 'txt')):\n",
-    "                yield r\n",
+    "            r,_ = _proc(d, args[0], pt=args[1] if len(args)>1 else None, kw=args[2] if len(args)>2 else 'txt')\n",
+    "            if r: yield r\n",
+    "    def _yield_srv(tid):\n",
+    "        srv_yielded.add(tid)\n",
+    "        return srv_tcs[tid]\n",
     "    stop, stop_yielded = False, False\n",
     "    async for d in it:\n",
     "        # Check stop condition and yield stop delta\n",
@@ -798,17 +802,30 @@
     "        # Rest incl. tools, finish reason, usage is processed independently\n",
     "        for tc in d.tool_calls:\n",
     "            args = tc.arguments.get('_delta', tc.arguments)\n",
-    "            _proc(d, 'tool_use', ret=dict(id=tc.id, name=tc.name, arguments=args, server=tc.server, extra=tc.extra))\n",
+    "            _,part = _proc(d, 'tool_use', ret=dict(id=tc.id, name=tc.name, arguments=args, server=tc.server, extra=tc.extra))\n",
+    "            # Stream complete server tool calls immediately\n",
+    "            if tc.server and tc.id and tc.name:\n",
+    "                srv_tcs[tc.id] = part\n",
+    "                if tc.arguments and isinstance(tc.arguments, dict) and '_delta' not in tc.arguments and tc.id not in srv_yielded:\n",
+    "                    yield _yield_srv(tc.id)\n",
     "        if d.server_tool_result:\n",
     "            idx = _fidx(d, 'server_tool_result')\n",
     "            part_accum.parts[idx] = Part(type=typ, data=d.server_tool_result)\n",
-    "        if (r:=_proc(d, 'refusal')): yield r\n",
+    "            tid = d.server_tool_result.get('tool_use_id')\n",
+    "            # Avoid duplicating tool calls already yielded during streaming\n",
+    "            if (acc:=srv_tcs.get(tid)) and tid not in srv_yielded:\n",
+    "                if isinstance(acc.arguments, str):\n",
+    "                    try: acc.arguments = json.loads(acc.arguments) if acc.arguments else {}\n",
+    "                    except json.JSONDecodeError: pass\n",
+    "                yield _yield_srv(tid)\n",
+    "        r,_ = _proc(d, 'refusal')\n",
+    "        if r: yield r\n",
     "        if d.finish_reason: fin = d.finish_reason\n",
     "        if d.usage: usg = d.usage\n",
     "        last_typ = typ\n",
     "        deltas.append(d)\n",
     "    part_accum.finalize()\n",
-    "    tcs = part_accum.tool_calls\n",
+    "    tcs = [t for t in part_accum.tool_calls if not (t.server and t.id in srv_yielded)]\n",
     "    if api_name: usg = api_registry.apis[api_name].finalize_usage(usg, part_accum.parts)\n",
     "    if stop: fin = FinishReason.stop\n",
     "    fin = FinishReason.tool_calls if fin==FinishReason.stop and any(~L(tcs).attrgot('server')) else fin # recheck tool calls post collation\n",
@@ -816,7 +833,7 @@
     "    yield Completion(d.raw.get('model', model),\n",
     "            message=Msg(role=\"assistant\", content=part_accum.parts),\n",
     "            finish_reason=fin, usage=usg, tool_calls=tcs, api_name=api_name, vendor_name=vendor_name,\n",
-    "            raw={'deltas':deltas})\n"
+    "            raw={'deltas':deltas})"
    ]
   },
   {
@@ -877,8 +894,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "async def detlas_gen(deltas): \n",
+    "async def deltas_gen(deltas): \n",
     "    for d in deltas: yield d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96e22d74",
+   "metadata": {},
+   "source": [
+    "Server tool calls should be yielded as soon as they are complete, and not duplicated in the final `Completion.tool_calls`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3a903a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "server_tool_delta = Delta(tool_calls=[ToolCall(id='srv_1', name='web_search', arguments={'query':'fastai'}, server=True)])\n",
+    "seen = [o async for o in mk_acollect_stream(deltas_gen([server_tool_delta]), delta_index_fn)]\n",
+    "test_eq([type(o) for o in seen], [ToolCall, Completion])\n",
+    "test_eq(seen[0].id, 'srv_1')\n",
+    "test_eq(seen[0].arguments, {'query':'fastai'})\n",
+    "test_eq(seen[-1].tool_calls, [])"
    ]
   },
   {
@@ -890,7 +930,7 @@
    "source": [
     "async def collect_txt(deltas, **kwargs):\n",
     "    txt = ''\n",
-    "    async for o in mk_acollect_stream(detlas_gen(deltas), delta_index_fn, **kwargs): \n",
+    "    async for o in mk_acollect_stream(deltas_gen(deltas), delta_index_fn, **kwargs): \n",
     "        if isinstance(o, dict): txt += o.get('text', '')\n",
     "    return txt"
    ]
@@ -979,10 +1019,10 @@
  ],
  "metadata": {
   "solveit": {
-   "default_code": true,
+   "default_code": false,
    "mode": "learning",
    "use_fence": false,
-   "use_thinking": false,
+   "use_thinking": true,
    "use_tools": true,
    "ver": 2
   }

--- a/nbs/02_oai_responses.ipynb
+++ b/nbs/02_oai_responses.ipynb
@@ -736,7 +736,7 @@
     "    max_print = 10\n",
     "    cnt = 0\n",
     "    def print_stream(self,o,postproc=noop):\n",
-    "        if not isinstance(o, Completion): \n",
+    "        if not isinstance(o, (Completion, ToolCall)):\n",
     "            if o.get('thinking') and self.cnt<self.max_print: print('🧠',end='',flush=True)\n",
     "            if (txt:=o.get('text')): print(txt,end='',flush=True)\n",
     "            if citations:= o.get('citations'): print(postproc(citations),end='',flush=True)\n",
@@ -3644,7 +3644,16 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit": {
+   "default_code": true,
+   "mode": "learning",
+   "use_fence": false,
+   "use_thinking": false,
+   "use_tools": true,
+   "ver": 2
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/nbs/04_anthropic.ipynb
+++ b/nbs/04_anthropic.ipynb
@@ -874,7 +874,7 @@
     "    max_print = 10\n",
     "    cnt = 0\n",
     "    def print_stream(self,o,postproc=noop):\n",
-    "        if not isinstance(o, Completion): \n",
+    "        if not isinstance(o, (Completion, ToolCall)):\n",
     "            if o.get('thinking') and self.cnt<self.max_print: print('🧠',end='',flush=True)\n",
     "            if (txt:=o.get('text')): print(txt,end='',flush=True)\n",
     "            if citations:= o.get('citations'): print(postproc(citations),end='',flush=True)\n",

--- a/nbs/06_acomplete.ipynb
+++ b/nbs/06_acomplete.ipynb
@@ -725,7 +725,7 @@
     "async def print_stream(msgs, model, max_print=100, **kwargs):\n",
     "    cnt,printed,done = 0,0,False\n",
     "    async for o in await acomplete(msgs, model, stream=True, **kwargs): \n",
-    "        if not isinstance(o, Completion) and not done: \n",
+    "        if not isinstance(o, (Completion, ToolCall)) and not done: \n",
     "            if o.get('thinking') and cnt<10: print('🧠',end='',flush=True)\n",
     "            if (txt:=o.get('text')):\n",
     "                if max_print is not None and printed+len(txt)>max_print:\n",

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastllm.types import Msg, Part, PartType, Completion\n",
+    "from fastllm.types import Msg, Part, PartType, Completion, ToolCall\n",
     "from fastllm.acomplete import acomplete, mk_tool_res_msg\n",
     "import asyncio, json\n",
     "\n",
@@ -70,7 +70,7 @@
     "    \"Stream a response, printing text/thinking as it arrives. Returns the final Completion.\"\n",
     "    cnt, max_think = 0, 10\n",
     "    async for o in await acomplete(msgs, model, stream=True, **kw):\n",
-    "        if not isinstance(o, Completion):\n",
+    "        if not isinstance(o, (Completion, ToolCall)):\n",
     "            if o.get('thinking') and cnt < max_think: print('🧠', end='', flush=True)\n",
     "            if txt := o.get('text'): print(txt, end='', flush=True)\n",
     "            cnt += 1\n",
@@ -3982,7 +3982,16 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit": {
+   "default_code": true,
+   "mode": "learning",
+   "use_fence": false,
+   "use_thinking": false,
+   "use_tools": true,
+   "ver": 2
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
Changes:
- Yield complete server tool calls (e.g. `web_search`) as soon as they arrive, rather than waiting for the full response to complete
- Track yielded server tools to avoid duplication in final `Completion.tool_calls`
- Update stream print helpers to handle ToolCall type in addition to Completion