### PR TITLE
fix truncation

### DIFF
--- a/fastllm/chat.py
+++ b/fastllm/chat.py
@@ -316,7 +316,7 @@ def _has_stop(tres_parts): return any(isinstance(p.text, StopResponse) for p in 
 def _trunc_str(s, mx=2000, skip=10, replace="TRUNCATED"):
     "Truncate `s` to `mx` chars max, adding `replace` if truncated"
     if not isinstance(s, str): s = str(s)
-    s = s.rstrip()
+    s = s.rstrip() if type(s) is str else type(s)(s.rstrip())
     if len(s)>2 and s[0]=='𝍁' and s[-1]=='𝍁':
         s = s[1:-1]
         if replace: return s

--- a/nbs/07_chat.ipynb
+++ b/nbs/07_chat.ipynb
@@ -35,22 +35,7 @@
    "execution_count": null,
    "id": "8076a07e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m15:28:57 - LiteLLM:WARNING\u001b[0m: common_utils.py:979 - litellm: could not pre-load bedrock-runtime response stream shape — Bedrock event-stream decoding will be unavailable. Error: No module named 'botocore'\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[92m15:28:57 - LiteLLM:WARNING\u001b[0m: common_utils.py:24 - litellm: could not pre-load sagemaker-runtime response stream shape — SageMaker event-stream decoding will be unavailable. Error: No module named 'botocore'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "enable_cachy(hdrs=('content-type',))"
@@ -4556,7 +4541,7 @@
     "def _trunc_str(s, mx=2000, skip=10, replace=\"TRUNCATED\"):\n",
     "    \"Truncate `s` to `mx` chars max, adding `replace` if truncated\"\n",
     "    if not isinstance(s, str): s = str(s)\n",
-    "    s = s.rstrip()\n",
+    "    s = s.rstrip() if type(s) is str else type(s)(s.rstrip())\n",
     "    if len(s)>2 and s[0]=='𝍁' and s[-1]=='𝍁':\n",
     "        s = s[1:-1]\n",
     "        if replace: return s\n",
@@ -4577,23 +4562,13 @@
    "execution_count": null,
    "id": "b2e3019a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "xxxxxxxxxx\n",
-      "<TRUNCATED>……</TRUNCATED>\n",
-      "<TRUNCATED>xxxxx…</TRUNCATED>\n",
-      "<TRUNCATED>…xxx…</TRUNCATED>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(_trunc_str('𝍁xxxxxxxxxx𝍁', mx=5))\n",
-    "print(_trunc_str(Safe('xxxxxxxxxx'), mx=5))\n",
-    "print(_trunc_str('xxxxxxxxxx', mx=5, skip=0))\n",
-    "print(_trunc_str('xxxxxxxxxx', mx=5, skip=1))"
+    "test_eq(_trunc_str('𝍁xxxxxxxxxx𝍁', mx=5), 'xxxxxxxxxx')\n",
+    "test_eq(_trunc_str(Safe('xxxxxxxxxx'), mx=5), 'xxxxxxxxxx')\n",
+    "test_eq(_trunc_str(FullResponse('xxxxxxxxxx'), mx=5), 'xxxxxxxxxx')\n",
+    "test_eq(_trunc_str('xxxxxxxxxx', mx=5, skip=0), '<TRUNCATED>xxxxx…</TRUNCATED>')\n",
+    "test_eq(_trunc_str('xxxxxxxxxx', mx=5, skip=1), '<TRUNCATED>…xxx…</TRUNCATED>')"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes response truncation. The issue was that `s.rstrip()` always returned a `str` even though `s` could be a subclass of `str` such as `FullResponse` or `Safe`.  I also added some tests.

I've made an identical PR to lisette.