### PR TITLE
Simplify _trunc_str: always use type(s) constructor for rstrip

### DIFF
--- a/fastllm/chat.py
+++ b/fastllm/chat.py
@@ -316,7 +316,7 @@ def _has_stop(tres_parts): return any(isinstance(p.text, StopResponse) for p in 
 def _trunc_str(s, mx=2000, skip=10, replace="TRUNCATED"):
     "Truncate `s` to `mx` chars max, adding `replace` if truncated"
     if not isinstance(s, str): s = str(s)
-    s = s.rstrip() if type(s) is str else type(s)(s.rstrip())
+    s = type(s)(s.rstrip())
     if len(s)>2 and s[0]=='𝍁' and s[-1]=='𝍁':
         s = s[1:-1]
         if replace: return s

--- a/nbs/07_chat.ipynb
+++ b/nbs/07_chat.ipynb
@@ -4541,7 +4541,7 @@
     "def _trunc_str(s, mx=2000, skip=10, replace=\"TRUNCATED\"):\n",
     "    \"Truncate `s` to `mx` chars max, adding `replace` if truncated\"\n",
     "    if not isinstance(s, str): s = str(s)\n",
-    "    s = s.rstrip() if type(s) is str else type(s)(s.rstrip())\n",
+    "    s = type(s)(s.rstrip())\n",
     "    if len(s)>2 and s[0]=='𝍁' and s[-1]=='𝍁':\n",
     "        s = s[1:-1]\n",
     "        if replace: return s\n",


### PR DESCRIPTION
After a tip from @jph00 