### PR TITLE
Add Meta AI vendor and muse-spark-1.1 model

### DIFF
--- a/fastllm/acomplete.py
+++ b/fastllm/acomplete.py
@@ -44,7 +44,8 @@ vendor_mapping = {
     "together":     ('openai_chat', "https://api.together.xyz/v1", "TOGETHER_API_KEY"),
     "fireworks_ai": ('openai_chat', "https://api.fireworks.ai/inference/v1", "FIREWORKS_API_KEY"),
     "qwen":         ('openai_chat', "https://dashscope.aliyuncs.com/compatible-mode/v1", "QWEN_API_KEY"),
-    "minimax":      ('anthropic', "https://api.minimax.io/anthropic", "MINIMAX_API_KEY")
+    "minimax":      ('anthropic', "https://api.minimax.io/anthropic", "MINIMAX_API_KEY"),
+    "meta_ai":      ('openai', "https://api.meta.ai/v1", "META_API_KEY")
 }
 
 # %% ../nbs/06_acomplete.ipynb #77d27ea7

--- a/fastllm/types.py
+++ b/fastllm/types.py
@@ -391,6 +391,13 @@ register_model_info('claude-fable-5', vendor_name='anthropic', base="claude-opus
         input_cost_per_token=10e-6, cache_creation_input_token_cost=12.5e-6, output_cost_per_token=50e-6,
         cache_read_input_token_cost=1e-6, search_context_cost_per_query=0.005)
 
+# %% ../nbs/00_types.ipynb #4e1b40b3
+register_model_info('muse-spark-1.1', vendor_name='meta_ai', **modern_llm,
+    max_input_tokens=1_048_576, max_output_tokens=128000, max_tokens=128000,
+    supports_vision=True, supports_image_input=True, supports_video_input=True, supports_pdf_input=True,
+    supports_web_search=True, search_context_cost_per_query=0.0025,
+    input_cost_per_token=1.25e-6, output_cost_per_token=4.25e-6, cache_read_input_token_cost=0.15e-6)
+
 # %% ../nbs/00_types.ipynb #2c23d11e
 codex_pricing = dict(
     input_cost_per_token = 0.10/1_000_000, output_cost_per_token = 0.50/1_000_000,

--- a/nbs/00_types.ipynb
+++ b/nbs/00_types.ipynb
@@ -1230,6 +1230,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4e1b40b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "register_model_info('muse-spark-1.1', vendor_name='meta_ai', **modern_llm,\n",
+    "    max_input_tokens=1_048_576, max_output_tokens=128000, max_tokens=128000,\n",
+    "    supports_vision=True, supports_image_input=True, supports_video_input=True, supports_pdf_input=True,\n",
+    "    supports_web_search=True, search_context_cost_per_query=0.0025,\n",
+    "    input_cost_per_token=1.25e-6, output_cost_per_token=4.25e-6, cache_read_input_token_cost=0.15e-6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2c23d11e",
    "metadata": {},
    "outputs": [],

--- a/nbs/06_acomplete.ipynb
+++ b/nbs/06_acomplete.ipynb
@@ -182,7 +182,8 @@
     "    \"together\":     ('openai_chat', \"https://api.together.xyz/v1\", \"TOGETHER_API_KEY\"),\n",
     "    \"fireworks_ai\": ('openai_chat', \"https://api.fireworks.ai/inference/v1\", \"FIREWORKS_API_KEY\"),\n",
     "    \"qwen\":         ('openai_chat', \"https://dashscope.aliyuncs.com/compatible-mode/v1\", \"QWEN_API_KEY\"),\n",
-    "    \"minimax\":      ('anthropic', \"https://api.minimax.io/anthropic\", \"MINIMAX_API_KEY\")\n",
+    "    \"minimax\":      ('anthropic', \"https://api.minimax.io/anthropic\", \"MINIMAX_API_KEY\"),\n",
+    "    \"meta_ai\":      ('openai', \"https://api.meta.ai/v1\", \"META_API_KEY\")\n",
     "}"
    ]
   },


### PR DESCRIPTION
## Summary
 - Register `meta_ai` as a new OpenAI-compatible vendor using `https://api.meta.ai/v1` with `META_API_KEY`
 - Add `muse-spark-1.1` model info with 1M+ input tokens, 128k output, vision/image/video/pdf input, web search, and competitive pricing