### PR TITLE
Merge a `finalize` result into the terminal frame's usage, and honour a server-priced `cost`

### DIFF
--- a/fastllm/model_prices.json
+++ b/fastllm/model_prices.json
@@ -553,6 +553,27 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "amazon.nova-sonic-v1:0": {
+        "deprecation_date": "2026-09-14",
+        "input_cost_per_audio_token": 3.4e-06,
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "bedrock",
+        "mode": "realtime",
+        "output_cost_per_audio_token": 1.36e-05,
+        "output_cost_per_token": 2.4e-07,
+        "supports_audio_input": true,
+        "supports_audio_output": true
+    },
+    "amazon.nova-2-sonic-v1:0": {
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "bedrock",
+        "mode": "realtime",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2.75e-06,
+        "supports_audio_input": true,
+        "supports_audio_output": true
+    },
     "amazon.rerank-v1:0": {
         "input_cost_per_query": 0.001,
         "input_cost_per_token": 0.0,
@@ -1430,6 +1451,44 @@
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
     },
+    "anthropic.claude-fable-5-1": {
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_mid_conversation_system": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": false,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh",
+        "supports_parallel_tool_use_config": true,
+        "prompt_cache_min_tokens": 512
+    },
     "global.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.25e-05,
         "cache_creation_input_token_cost_above_1hr": 2e-05,
@@ -1461,6 +1520,44 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh",
+        "supports_parallel_tool_use_config": true,
+        "prompt_cache_min_tokens": 512
+    },
+    "global.anthropic.claude-fable-5-1": {
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_mid_conversation_system": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
@@ -1504,6 +1601,44 @@
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
     },
+    "us.anthropic.claude-fable-5-1": {
+        "cache_creation_input_token_cost": 1.375e-05,
+        "cache_creation_input_token_cost_above_1hr": 2.2e-05,
+        "cache_read_input_token_cost": 2.75e-07,
+        "input_cost_per_token": 1.1e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_mid_conversation_system": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": false,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh",
+        "supports_parallel_tool_use_config": true,
+        "prompt_cache_min_tokens": 512
+    },
     "eu.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.375e-05,
         "cache_creation_input_token_cost_above_1hr": 2.2e-05,
@@ -1541,6 +1676,44 @@
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
     },
+    "eu.anthropic.claude-fable-5-1": {
+        "cache_creation_input_token_cost": 1.375e-05,
+        "cache_creation_input_token_cost_above_1hr": 2.2e-05,
+        "cache_read_input_token_cost": 2.75e-07,
+        "input_cost_per_token": 1.1e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5.5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_mid_conversation_system": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_native_structured_output": false,
+        "supports_max_reasoning_effort": true,
+        "supports_output_config": true,
+        "bedrock_output_config_effort_ceiling": "xhigh",
+        "supports_parallel_tool_use_config": true,
+        "prompt_cache_min_tokens": 512
+    },
     "anthropic.claude-opus-5": {
         "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
@@ -1571,7 +1744,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
@@ -1607,7 +1780,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
@@ -1643,7 +1816,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
@@ -1679,7 +1852,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
@@ -1715,7 +1888,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
@@ -1751,7 +1924,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
@@ -2044,7 +2217,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
@@ -2081,7 +2254,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
@@ -2118,7 +2291,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
@@ -2155,7 +2328,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
@@ -2192,7 +2365,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
@@ -2229,7 +2402,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true,
+        "supports_native_structured_output": false,
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
@@ -3025,6 +3198,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "azure_ai/claude-fable-5": {
+        "deprecation_date": "2027-12-05",
         "supports_mid_conversation_system": true,
         "input_cost_per_token": 1e-05,
         "output_cost_per_token": 5e-05,
@@ -3057,7 +3231,43 @@
         "supports_max_reasoning_effort": true,
         "prompt_cache_min_tokens": 512
     },
+    "azure_ai/claude-fable-5-1": {
+        "supports_mid_conversation_system": true,
+        "input_cost_per_token": 1e-05,
+        "output_cost_per_token": 5e-05,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_native_structured_output": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "prompt_cache_min_tokens": 512
+    },
     "azure_ai/claude-opus-5": {
+        "deprecation_date": "2027-07-08",
         "supports_mid_conversation_system": true,
         "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
@@ -3090,6 +3300,7 @@
         "prompt_cache_min_tokens": 512
     },
     "azure_ai/claude-opus-4-8": {
+        "deprecation_date": "2027-09-01",
         "supports_mid_conversation_system": true,
         "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
@@ -3168,6 +3379,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "azure_ai/claude-sonnet-5": {
+        "deprecation_date": "2027-06-30",
         "supports_mid_conversation_system": true,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
@@ -3726,7 +3938,7 @@
         "output_cost_per_token": 0,
         "litellm_provider": "azure_ai",
         "mode": "chat",
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-services/",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/aoai/",
         "comment": "Flat cost of $0.14 per M input tokens for Azure AI Foundry Model Router infrastructure. Use pattern: azure_ai/model_router/<deployment-name> where deployment-name is your Azure deployment (e.g., azure-model-router)"
     },
     "azure/eu/gpt-4o-2024-08-06": {
@@ -5328,7 +5540,7 @@
         "input_cost_per_second": 0.0002833333333333333,
         "litellm_provider": "azure",
         "mode": "audio_transcription",
-        "source": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/gpt-realtime-whisper",
+        "source": "https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/gpt-realtime-whisper",
         "supported_endpoints": [
             "/v1/realtime",
             "/v1/realtime/transcription_sessions"
@@ -9107,7 +9319,7 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
-        "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
         "supports_embedding_image_input": true
     },
     "azure_ai/Cohere-embed-v3-multilingual": {
@@ -9118,7 +9330,7 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
-        "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
         "supports_embedding_image_input": true
     },
     "azure_ai/FLUX-1.1-pro": {
@@ -9134,7 +9346,7 @@
         "litellm_provider": "azure_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
-        "source": "https://azuremarketplace.microsoft.com/pt-br/marketplace/apps/cohere.cohere-embed-4-offer?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/pt-br/marketplace/apps/cohere.cohere-embed-4-offer?tab=PlansAndPrice",
         "supported_endpoints": [
             "/v1/images/generations"
         ]
@@ -9467,7 +9679,7 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 3.7e-07,
-        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-11b-vision-instruct-offer?tab=Overview",
+        "source": "https://marketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-11b-vision-instruct-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -9481,7 +9693,7 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 2.04e-06,
-        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-90b-vision-instruct-offer?tab=Overview",
+        "source": "https://marketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-90b-vision-instruct-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -9494,7 +9706,7 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 7.1e-07,
-        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.llama-3-3-70b-instruct-offer?tab=Overview",
+        "source": "https://marketplace.microsoft.com/en/marketplace/apps/metagenai.llama-3-3-70b-instruct-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
@@ -9543,7 +9755,7 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 1.6e-05,
-        "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-405b-instruct-offer?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-405b-instruct-offer?tab=PlansAndPrice",
         "supports_tool_choice": true
     },
     "azure_ai/Meta-Llama-3.1-70B-Instruct": {
@@ -9554,7 +9766,7 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 3.54e-06,
-        "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-70b-instruct-offer?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-70b-instruct-offer?tab=PlansAndPrice",
         "supports_tool_choice": true
     },
     "azure_ai/Meta-Llama-3.1-8B-Instruct": {
@@ -9566,7 +9778,7 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 6.1e-07,
-        "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-8b-instruct-offer?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-8b-instruct-offer?tab=PlansAndPrice",
         "supports_tool_choice": true
     },
     "azure_ai/Phi-3-medium-128k-instruct": {
@@ -9756,7 +9968,7 @@
         "supported_endpoints": [
             "/v1/ocr"
         ],
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/"
+        "source": "https://ai.azure.com/catalog/models/mistral-document-ai-2512"
     },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
@@ -9959,6 +10171,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "azure_ai/deepseek-v4-flash-0731": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "deprecation_date": "2026-12-03",
+        "input_cost_per_token": 1.9e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5.1e-07,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "azure_ai/embed-v-4-0": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "azure_ai",
@@ -9967,7 +10195,7 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0,
         "output_vector_size": 3072,
-        "source": "https://azuremarketplace.microsoft.com/pt-br/marketplace/apps/cohere.cohere-embed-4-offer?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/pt-br/marketplace/apps/cohere.cohere-embed-4-offer?tab=PlansAndPrice",
         "supported_endpoints": [
             "/v1/embeddings"
         ],
@@ -10151,7 +10379,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 0.00971,
-        "source": "https://azure.microsoft.com/en-us/products/ai-services/ai-foundry/models/jais-30b-chat"
+        "source": "https://ai.azure.com/catalog/models/jais-30b-chat"
     },
     "azure_ai/jamba-instruct": {
         "input_cost_per_token": 5e-07,
@@ -10208,7 +10436,7 @@
         "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 4e-08,
-        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.ministral-3b-2410-offer?tab=Overview",
+        "source": "https://marketplace.microsoft.com/en/marketplace/apps/000-000.ministral-3b-2410-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
@@ -10231,7 +10459,7 @@
         "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 6e-06,
-        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
+        "source": "https://marketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
@@ -10243,7 +10471,7 @@
         "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 6e-06,
-        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
+        "source": "https://marketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
@@ -10280,7 +10508,7 @@
         "max_tokens": 4096,
         "mode": "chat",
         "output_cost_per_token": 1.5e-07,
-        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-nemo-12b-2407?tab=PlansAndPrice",
+        "source": "https://marketplace.microsoft.com/en/marketplace/apps/000-000.mistral-nemo-12b-2407?tab=PlansAndPrice",
         "supports_function_calling": true
     },
     "azure_ai/mistral-small": {
@@ -12267,6 +12495,7 @@
         "supports_tool_choice": true
     },
     "cerebras/zai-glm-4.7": {
+        "deprecation_date": "2026-08-17",
         "input_cost_per_token": 2.25e-06,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,
@@ -12315,7 +12544,8 @@
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
-        ]
+        ],
+        "deprecation_date": "2027-02-26"
     },
     "claude-haiku-4-5-20251001": {
         "deprecation_date": "2026-10-15",
@@ -13000,6 +13230,47 @@
         "prompt_cache_min_tokens": 512,
         "supports_native_structured_output": true,
         "source": "https://docs.anthropic.com/en/docs/about-claude/models/overview"
+    },
+    "claude-fable-5-1": {
+        "deprecation_date": "2027-09-01",
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_mid_conversation_system": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "provider_specific_entry": {
+            "us": 1.1
+        },
+        "supports_output_config": true,
+        "prompt_cache_min_tokens": 512,
+        "supports_native_structured_output": true,
+        "source": "https://platform.claude.com/docs/en/models/fable-5-1/overview"
     },
     "claude-opus-5": {
         "deprecation_date": "2027-07-24",
@@ -14697,6 +14968,1910 @@
             "/v1/images/generations"
         ]
     },
+    "qwencloud/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 4e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/deepseek-v4-flash-0731": {
+        "cache_read_input_token_cost": 4e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/deepseek-v4-pro": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 2.4e-06,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4.8e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/glm-5.1": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 202745,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/glm-5.2": {
+        "cache_read_input_token_cost": 2.8e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 229376,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwencloud/qwen-coder": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-flash": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 5e-08,
+                "output_cost_per_token": 4e-07,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.5e-07,
+                "output_cost_per_token": 2e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen-flash-2025-07-28": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 5e-08,
+                "output_cost_per_token": 4e-07,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.5e-07,
+                "output_cost_per_token": 2e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen-max": {
+        "input_cost_per_token": 1.6e-06,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 30720,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6.4e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-plus": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-plus-2025-01-25": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-plus-2025-04-28": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 4e-06,
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-plus-2025-07-14": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 4e-06,
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-plus-2025-07-28": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_reasoning_token": 4e-06,
+                "output_cost_per_token": 1.2e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_reasoning_token": 1.2e-05,
+                "output_cost_per_token": 3.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen-plus-2025-09-11": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_reasoning_token": 4e-06,
+                "output_cost_per_token": 1.2e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_reasoning_token": 1.2e-05,
+                "output_cost_per_token": 3.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen-plus-latest": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_reasoning_token": 4e-06,
+                "output_cost_per_token": 1.2e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_reasoning_token": 1.2e-05,
+                "output_cost_per_token": 3.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen-turbo": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 5e-07,
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-turbo-2024-11-01": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-turbo-2025-04-28": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 5e-07,
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-turbo-latest": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 5e-07,
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen3-30b-a3b": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen3-coder-flash": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "cache_read_input_token_cost": 8e-08,
+                "input_cost_per_token": 3e-07,
+                "output_cost_per_token": 1.5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 1.2e-07,
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 2.5e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 2e-07,
+                "input_cost_per_token": 8e-07,
+                "output_cost_per_token": 4e-06,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 4e-07,
+                "input_cost_per_token": 1.6e-06,
+                "output_cost_per_token": 9.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3-coder-flash-2025-07-28": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 3e-07,
+                "output_cost_per_token": 1.5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 2.5e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 8e-07,
+                "output_cost_per_token": 4e-06,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.6e-06,
+                "output_cost_per_token": 9.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3-coder-plus": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "cache_read_input_token_cost": 1e-07,
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 1.8e-07,
+                "input_cost_per_token": 1.8e-06,
+                "output_cost_per_token": 9e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 3e-07,
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 6e-07,
+                "input_cost_per_token": 6e-06,
+                "output_cost_per_token": 6e-05,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3-coder-plus-2025-07-22": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.8e-06,
+                "output_cost_per_token": 9e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 6e-06,
+                "output_cost_per_token": 6e-05,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3-max-preview": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3-max": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3-max-2026-01-23": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3-next-80b-a3b-instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen3-next-80b-a3b-thinking": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen3-vl-235b-a22b-instruct": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwencloud/qwen3-vl-235b-a22b-thinking": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwencloud/qwen3-vl-32b-instruct": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 6.4e-07,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwencloud/qwen3-vl-32b-thinking": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.87e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwencloud/qwen3-vl-plus": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 260096,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 2e-07,
+                "output_cost_per_token": 1.6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-07,
+                "output_cost_per_token": 2.4e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 6e-07,
+                "output_cost_per_token": 4.8e-06,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3.5-plus": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_token": 2.4e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3.7-max": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen3.7-plus": {
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "cache_read_input_token_cost": 8e-08,
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_token": 1.6e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 2.4e-07,
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 4.8e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwencloud/qwen3.8-max": {
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwencloud/qwq-plus": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "qwencloud",
+        "max_input_tokens": 98304,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://www.qwencloud.com/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwencloud/qwen-image-2.0": {
+        "litellm_provider": "qwencloud",
+        "mode": "image_generation",
+        "source": "https://www.qwencloud.com/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "qwencloud/qwen-image-2.0-pro": {
+        "litellm_provider": "qwencloud",
+        "mode": "image_generation",
+        "source": "https://www.qwencloud.com/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "qwencloud/qwen-image-3.0": {
+        "litellm_provider": "qwencloud",
+        "mode": "image_generation",
+        "source": "https://www.qwencloud.com/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "qwencloud/qwen-image-3.0-pro": {
+        "litellm_provider": "qwencloud",
+        "mode": "image_generation",
+        "source": "https://www.qwencloud.com/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "qwen_ai_platform/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 4e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/deepseek-v4-flash-0731": {
+        "cache_read_input_token_cost": 4e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/deepseek-v4-pro": {
+        "cache_read_input_token_cost": 2e-07,
+        "input_cost_per_token": 2.4e-06,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 4.8e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/glm-5.1": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 202745,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/glm-5.2": {
+        "cache_read_input_token_cost": 2.8e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 229376,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwen_ai_platform/qwen-coder": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-flash": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 5e-08,
+                "output_cost_per_token": 4e-07,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.5e-07,
+                "output_cost_per_token": 2e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen-flash-2025-07-28": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 5e-08,
+                "output_cost_per_token": 4e-07,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.5e-07,
+                "output_cost_per_token": 2e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen-max": {
+        "input_cost_per_token": 1.6e-06,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 30720,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6.4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-plus": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-plus-2025-01-25": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-plus-2025-04-28": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 4e-06,
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-plus-2025-07-14": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 4e-06,
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-plus-2025-07-28": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_reasoning_token": 4e-06,
+                "output_cost_per_token": 1.2e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_reasoning_token": 1.2e-05,
+                "output_cost_per_token": 3.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen-plus-2025-09-11": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_reasoning_token": 4e-06,
+                "output_cost_per_token": 1.2e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_reasoning_token": 1.2e-05,
+                "output_cost_per_token": 3.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen-plus-latest": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_reasoning_token": 4e-06,
+                "output_cost_per_token": 1.2e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_reasoning_token": 1.2e-05,
+                "output_cost_per_token": 3.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen-turbo": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 5e-07,
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-turbo-2024-11-01": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-turbo-2025-04-28": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 5e-07,
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-turbo-latest": {
+        "input_cost_per_token": 5e-08,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 5e-07,
+        "output_cost_per_token": 2e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen3-30b-a3b": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen3-coder-flash": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "cache_read_input_token_cost": 8e-08,
+                "input_cost_per_token": 3e-07,
+                "output_cost_per_token": 1.5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 1.2e-07,
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 2.5e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 2e-07,
+                "input_cost_per_token": 8e-07,
+                "output_cost_per_token": 4e-06,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 4e-07,
+                "input_cost_per_token": 1.6e-06,
+                "output_cost_per_token": 9.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3-coder-flash-2025-07-28": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 3e-07,
+                "output_cost_per_token": 1.5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 2.5e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 8e-07,
+                "output_cost_per_token": 4e-06,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.6e-06,
+                "output_cost_per_token": 9.6e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3-coder-plus": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "cache_read_input_token_cost": 1e-07,
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 1.8e-07,
+                "input_cost_per_token": 1.8e-06,
+                "output_cost_per_token": 9e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 3e-07,
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 6e-07,
+                "input_cost_per_token": 6e-06,
+                "output_cost_per_token": 6e-05,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3-coder-plus-2025-07-22": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 997952,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 5e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 1.8e-06,
+                "output_cost_per_token": 9e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 6e-06,
+                "output_cost_per_token": 6e-05,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3-max-preview": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3-max": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3-max-2026-01-23": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 258048,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 2.4e-06,
+                "output_cost_per_token": 1.2e-05,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-06,
+                "output_cost_per_token": 1.5e-05,
+                "range": [
+                    128000.0,
+                    252000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3-next-80b-a3b-instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen3-next-80b-a3b-thinking": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen3-vl-235b-a22b-instruct": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwen_ai_platform/qwen3-vl-235b-a22b-thinking": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwen_ai_platform/qwen3-vl-32b-instruct": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 6.4e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwen_ai_platform/qwen3-vl-32b-thinking": {
+        "input_cost_per_token": 1.6e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.87e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/model-pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwen_ai_platform/qwen3-vl-plus": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 260096,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 2e-07,
+                "output_cost_per_token": 1.6e-06,
+                "range": [
+                    0,
+                    32000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 3e-07,
+                "output_cost_per_token": 2.4e-06,
+                "range": [
+                    32000.0,
+                    128000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 6e-07,
+                "output_cost_per_token": 4.8e-06,
+                "range": [
+                    128000.0,
+                    256000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3.5-plus": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_token": 2.4e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "input_cost_per_token": 5e-07,
+                "output_cost_per_token": 3e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3.7-max": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen3.7-plus": {
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "tiered_pricing": [
+            {
+                "cache_read_input_token_cost": 8e-08,
+                "input_cost_per_token": 4e-07,
+                "output_cost_per_token": 1.6e-06,
+                "range": [
+                    0,
+                    256000.0
+                ]
+            },
+            {
+                "cache_read_input_token_cost": 2.4e-07,
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 4.8e-06,
+                "range": [
+                    256000.0,
+                    1000000.0
+                ]
+            }
+        ]
+    },
+    "qwen_ai_platform/qwen3.8-max": {
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 991808,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "qwen_ai_platform/qwq-plus": {
+        "input_cost_per_token": 8e-07,
+        "litellm_provider": "qwen_ai_platform",
+        "max_input_tokens": 98304,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen_ai_platform/qwen-image-2.0": {
+        "litellm_provider": "qwen_ai_platform",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "qwen_ai_platform/qwen-image-2.0-pro": {
+        "litellm_provider": "qwen_ai_platform",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "qwen_ai_platform/qwen-image-3.0": {
+        "litellm_provider": "qwen_ai_platform",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "qwen_ai_platform/qwen-image-3.0-pro": {
+        "litellm_provider": "qwen_ai_platform",
+        "mode": "image_generation",
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
     "databricks/databricks-bge-large-en": {
         "cache_creation_input_token_cost": 1.0003e-07,
         "cache_read_input_token_cost": 1.0003e-07,
@@ -15079,6 +17254,62 @@
         "supports_sampling_params": false,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "databricks/databricks-deepseek-v4-flash-0731": {
+        "cache_creation_input_token_cost": 1.4e-07,
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 1.4e-07,
+        "input_dbu_cost_per_token": 2e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Billing reads the per-token dollar fields; the '*_dbu_cost_per_token' fields are the published Databricks rates, kept for reference. Context/max output are the DeepSeek-published model limits (1M context, 384K max output)."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "output_dbu_cost_per_token": 4e-06,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
+    "databricks/databricks-deepseek-v4-pro-0813": {
+        "cache_creation_input_token_cost": 1.31999e-06,
+        "cache_read_input_token_cost": 1.3202e-07,
+        "input_cost_per_token": 1.31999e-06,
+        "input_dbu_cost_per_token": 1.8857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Billing reads the per-token dollar fields; the '*_dbu_cost_per_token' fields are the published Databricks rates, kept for reference. Context/max output are the DeepSeek-published model limits (1M context, 384K max output)."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 3.95997e-06,
+        "output_dbu_cost_per_token": 5.6571e-05,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
     },
     "databricks/databricks-gemini-2-5-flash": {
         "cache_creation_input_token_cost": 3.0002e-07,
@@ -17767,7 +19998,8 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "deprecation_date": "2027-01-08"
     },
     "eu.anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
@@ -19564,6 +21796,61 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "friendliai/zai-org/GLM-5.3-Flash": {
+        "litellm_provider": "friendliai",
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "max_input_tokens": 1048576,
+        "max_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 5e-07,
+        "cache_read_input_token_cost": 3e-08,
+        "supports_prompt_caching": true,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_native_structured_output": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "mode": "chat",
+        "comment": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+        "source": "https://api.friendli.ai/serverless/v1/models",
+        "supports_vision": true,
+        "supports_image_input": true,
+        "supports_video_input": true
+    },
+    "friendliai/zai-org/GLM-5.3": {
+        "litellm_provider": "friendliai",
+        "supports_reasoning": true,
+        "supports_function_calling": true,
+        "max_input_tokens": 1048576,
+        "max_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "input_cost_per_token": 1.26e-06,
+        "output_cost_per_token": 3.96e-06,
+        "cache_read_input_token_cost": 2.34e-07,
+        "supports_prompt_caching": true,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_native_structured_output": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "mode": "chat",
+        "comment": "Flagship GLM model for long-horizon coding, agents, and complex project delivery",
+        "source": "https://api.friendli.ai/serverless/v1/models",
+        "supports_vision": false,
+        "supports_image_input": false
+    },
     "ft:babbage-002": {
         "deprecation_date": "2026-10-23",
         "input_cost_per_token": 1.6e-06,
@@ -20554,6 +22841,7 @@
         "supports_image_size": false
     },
     "gemini-live-2.5-flash-native-audio": {
+        "deprecation_date": "2026-12-13",
         "input_cost_per_audio_token": 3e-06,
         "input_cost_per_token": 5e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -22843,7 +25131,7 @@
         "output_cost_per_reasoning_token": 3e-06,
         "output_cost_per_token": 3e-06,
         "rpm": 2000,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -22897,7 +25185,7 @@
         "output_cost_per_reasoning_token": 9e-06,
         "output_cost_per_token": 9e-06,
         "rpm": 2000,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -22962,7 +25250,7 @@
         "output_cost_per_token_batches": 1.875e-06,
         "output_cost_per_token_flex": 1.875e-06,
         "rpm": 2000,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -23021,7 +25309,7 @@
         "output_cost_per_token_batches": 1.875e-06,
         "output_cost_per_token_flex": 1.875e-06,
         "rpm": 2000,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -23226,7 +25514,7 @@
         "mode": "chat",
         "output_cost_per_reasoning_token": 3e-06,
         "output_cost_per_token": 3e-06,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -23310,7 +25598,7 @@
         "mode": "chat",
         "output_cost_per_reasoning_token": 9e-06,
         "output_cost_per_token": 9e-06,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -23373,7 +25661,7 @@
         "output_cost_per_token": 3.75e-06,
         "output_cost_per_token_batches": 1.875e-06,
         "output_cost_per_token_flex": 1.875e-06,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -23430,7 +25718,7 @@
         "output_cost_per_token": 3.75e-06,
         "output_cost_per_token_batches": 1.875e-06,
         "output_cost_per_token_flex": 1.875e-06,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -23775,8 +26063,10 @@
         "max_input_tokens": 1024,
         "max_tokens": 1024,
         "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
+        "output_cost_per_second": 0.1,
+        "output_cost_per_second_1080p": 0.12,
+        "output_cost_per_second_4k": 0.3,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -23790,7 +26080,8 @@
         "max_tokens": 1024,
         "mode": "video_generation",
         "output_cost_per_second": 0.4,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
+        "output_cost_per_second_4k": 0.6,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -23818,8 +26109,10 @@
         "max_input_tokens": 1024,
         "max_tokens": 1024,
         "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
+        "output_cost_per_second": 0.1,
+        "output_cost_per_second_1080p": 0.12,
+        "output_cost_per_second_4k": 0.3,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -23833,7 +26126,8 @@
         "max_tokens": 1024,
         "mode": "video_generation",
         "output_cost_per_second": 0.4,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
+        "output_cost_per_second_4k": 0.6,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -24342,7 +26636,7 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
-    "gigachat/GigaChat-2-Lite": {
+    "gigachat/GigaChat-2": {
         "input_cost_per_token": 0.0,
         "litellm_provider": "gigachat",
         "max_input_tokens": 128000,
@@ -24403,6 +26697,15 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0,
         "output_vector_size": 2560
+    },
+    "gigachat/GigaEmbeddings-3B-2025-09": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "gigachat",
+        "max_input_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 2048
     },
     "gmi/anthropic/claude-opus-4.5": {
         "input_cost_per_token": 5e-06,
@@ -25327,7 +27630,7 @@
         "supports_vision": true
     },
     "gpt-4o-audio-preview": {
-        "deprecation_date": "2027-01-20",
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -25650,7 +27953,7 @@
         "supports_vision": true
     },
     "gpt-4o-mini-audio-preview": {
-        "deprecation_date": "2027-01-20",
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openai",
@@ -25688,7 +27991,7 @@
     "gpt-4o-mini-realtime-preview": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
-        "deprecation_date": "2027-01-20",
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openai",
@@ -25787,7 +28090,8 @@
         "output_cost_per_token": 5e-06,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
-        ]
+        ],
+        "deprecation_date": "2027-02-26"
     },
     "gpt-4o-mini-tts": {
         "input_cost_per_token": 2.5e-06,
@@ -25809,7 +28113,7 @@
     },
     "gpt-4o-realtime-preview": {
         "cache_read_input_token_cost": 2.5e-06,
-        "deprecation_date": "2027-01-20",
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -25828,7 +28132,7 @@
     },
     "gpt-4o-realtime-preview-2024-12-17": {
         "cache_read_input_token_cost": 2.5e-06,
-        "deprecation_date": "2027-01-20",
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -25847,7 +28151,7 @@
     },
     "gpt-4o-realtime-preview-2025-06-03": {
         "cache_read_input_token_cost": 2.5e-06,
-        "deprecation_date": "2027-01-20",
+        "deprecation_date": "2026-05-07",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
@@ -25926,7 +28230,8 @@
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
-        ]
+        ],
+        "deprecation_date": "2027-02-26"
     },
     "gpt-image-1.5": {
         "cache_read_input_token_cost": 1.25e-06,
@@ -27077,7 +29382,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "source": "https://platform.openai.com/docs/models/gpt-5.6-cyber",
+        "source": "https://developers.openai.com/api/docs/models/gpt-5.6-cyber",
         "supports_computer_use": true,
         "supports_parallel_function_calling": true
     },
@@ -27116,7 +29421,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "source": "https://platform.openai.com/docs/models/daybreak-red-latest",
+        "source": "https://developers.openai.com/api/docs/models/daybreak-red-latest",
         "supports_computer_use": true,
         "supports_parallel_function_calling": true
     },
@@ -27156,7 +29461,7 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "source": "https://platform.openai.com/docs/models/daybreak-blue-latest",
+        "source": "https://developers.openai.com/api/docs/models/daybreak-blue-latest",
         "supports_parallel_function_calling": true
     },
     "chat-latest": {
@@ -27168,7 +29473,7 @@
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 3e-05,
-        "source": "https://platform.openai.com/docs/models/chat-latest",
+        "source": "https://developers.openai.com/api/docs/models/chat-latest",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -30463,7 +32768,7 @@
             "search_context_size_low": 0.0025,
             "search_context_size_medium": 0.0025
         },
-        "source": "https://dev.meta.ai/docs/getting-started/pricing-rate-limits",
+        "source": "https://ai.developer.meta.com/docs/pricing-rate-limits",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses",
@@ -30504,7 +32809,7 @@
             "search_context_size_low": 0.0025,
             "search_context_size_medium": 0.0025
         },
-        "source": "https://dev.meta.ai/docs/getting-started/pricing-rate-limits",
+        "source": "https://ai.developer.meta.com/docs/pricing-rate-limits",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses",
@@ -30545,7 +32850,7 @@
             "search_context_size_low": 0.0025,
             "search_context_size_medium": 0.0025
         },
-        "source": "https://dev.meta.ai/docs/getting-started/pricing-rate-limits",
+        "source": "https://ai.developer.meta.com/docs/pricing-rate-limits",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses",
@@ -30578,7 +32883,7 @@
         "max_output_tokens": 4028,
         "max_tokens": 4028,
         "mode": "chat",
-        "source": "https://llama.developer.meta.com/docs/models",
+        "source": "https://ai.developer.meta.com/docs/models",
         "supported_modalities": [
             "text"
         ],
@@ -30594,7 +32899,7 @@
         "max_output_tokens": 4028,
         "max_tokens": 4028,
         "mode": "chat",
-        "source": "https://llama.developer.meta.com/docs/models",
+        "source": "https://ai.developer.meta.com/docs/models",
         "supported_modalities": [
             "text"
         ],
@@ -30610,7 +32915,7 @@
         "max_output_tokens": 4028,
         "max_tokens": 4028,
         "mode": "chat",
-        "source": "https://llama.developer.meta.com/docs/models",
+        "source": "https://ai.developer.meta.com/docs/models",
         "supported_modalities": [
             "text",
             "image"
@@ -30627,7 +32932,7 @@
         "max_output_tokens": 4028,
         "max_tokens": 4028,
         "mode": "chat",
-        "source": "https://llama.developer.meta.com/docs/models",
+        "source": "https://ai.developer.meta.com/docs/models",
         "supported_modalities": [
             "text",
             "image"
@@ -32572,7 +34877,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/deepseek-ai/DeepSeek-R1-0528": {
         "max_tokens": 164000,
@@ -32584,7 +34889,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
         "max_tokens": 128000,
@@ -32595,7 +34900,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/deepseek-ai/DeepSeek-V3": {
         "max_tokens": 128000,
@@ -32606,7 +34911,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/deepseek-ai/DeepSeek-V3-0324": {
         "max_tokens": 128000,
@@ -32617,7 +34922,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/google/gemma-3-27b-it": {
         "max_tokens": 128000,
@@ -32629,7 +34934,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_vision": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/meta-llama/Llama-3.3-70B-Instruct": {
         "max_tokens": 128000,
@@ -32640,7 +34945,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/meta-llama/Llama-Guard-3-8B": {
         "max_tokens": 128000,
@@ -32650,7 +34955,7 @@
         "output_cost_per_token": 6e-08,
         "litellm_provider": "nebius",
         "mode": "chat",
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/meta-llama/Meta-Llama-3.1-8B-Instruct": {
         "max_tokens": 128000,
@@ -32661,7 +34966,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/meta-llama/Meta-Llama-3.1-70B-Instruct": {
         "max_tokens": 128000,
@@ -32672,7 +34977,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/meta-llama/Meta-Llama-3.1-405B-Instruct": {
         "max_tokens": 128000,
@@ -32683,7 +34988,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/mistralai/Mistral-Nemo-Instruct-2407": {
         "max_tokens": 128000,
@@ -32694,7 +34999,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/NousResearch/Hermes-3-Llama-3.1-405B": {
         "max_tokens": 128000,
@@ -32705,7 +35010,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/nvidia/Llama-3.1-Nemotron-Ultra-253B-v1": {
         "max_tokens": 128000,
@@ -32716,7 +35021,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/nvidia/Llama-3.3-Nemotron-Super-49B-v1": {
         "max_tokens": 131072,
@@ -32727,7 +35032,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen3-235B-A22B": {
         "max_tokens": 262144,
@@ -32738,7 +35043,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen3-32B": {
         "max_tokens": 32768,
@@ -32749,7 +35054,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen3-30B-A3B": {
         "max_tokens": 32768,
@@ -32760,7 +35065,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen3-14B": {
         "max_tokens": 32768,
@@ -32771,7 +35076,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen3-4B": {
         "max_tokens": 32768,
@@ -32782,7 +35087,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/QwQ-32B": {
         "max_tokens": 32768,
@@ -32794,7 +35099,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_reasoning": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen2.5-72B-Instruct": {
         "max_tokens": 128000,
@@ -32805,7 +35110,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen2.5-32B-Instruct": {
         "max_tokens": 128000,
@@ -32816,7 +35121,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen2.5-Coder-7B": {
         "max_tokens": 32768,
@@ -32827,7 +35132,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_function_calling": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen2.5-VL-72B-Instruct": {
         "max_tokens": 131072,
@@ -32839,7 +35144,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_vision": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen2-VL-72B-Instruct": {
         "max_tokens": 131072,
@@ -32851,7 +35156,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_vision": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/Qwen/Qwen2-VL-7B-Instruct": {
         "max_tokens": 131072,
@@ -32862,7 +35167,7 @@
         "litellm_provider": "nebius",
         "mode": "chat",
         "supports_vision": true,
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/BAAI/bge-en-icl": {
         "max_tokens": 32768,
@@ -32871,7 +35176,7 @@
         "output_cost_per_token": 0.0,
         "litellm_provider": "nebius",
         "mode": "embedding",
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/BAAI/bge-multilingual-gemma2": {
         "max_tokens": 8192,
@@ -32880,7 +35185,7 @@
         "output_cost_per_token": 0.0,
         "litellm_provider": "nebius",
         "mode": "embedding",
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nebius/intfloat/e5-mistral-7b-instruct": {
         "max_tokens": 32768,
@@ -32889,7 +35194,7 @@
         "output_cost_per_token": 0.0,
         "litellm_provider": "nebius",
         "mode": "embedding",
-        "source": "https://nebius.com/prices-ai-studio"
+        "source": "https://nebius.com/prices"
     },
     "nvidia.nemotron-nano-12b-v2": {
         "input_cost_per_token": 2e-07,
@@ -33630,7 +35935,7 @@
         "max_tokens": 4000,
         "mode": "chat",
         "output_cost_per_token": 1.56e-06,
-        "source": "https://www.oracle.com/cloud/ai/generative-ai/pricing/",
+        "source": "https://www.oracle.com/artificial-intelligence/enterprise-ai/cost-estimator/",
         "supports_function_calling": true,
         "supports_response_schema": false,
         "supports_native_streaming": true
@@ -33643,7 +35948,7 @@
         "max_tokens": 4000,
         "mode": "chat",
         "output_cost_per_token": 1.56e-06,
-        "source": "https://www.oracle.com/cloud/ai/generative-ai/pricing/",
+        "source": "https://www.oracle.com/artificial-intelligence/enterprise-ai/cost-estimator/",
         "supports_function_calling": true,
         "supports_response_schema": false,
         "supports_native_streaming": true
@@ -33656,7 +35961,7 @@
         "max_tokens": 4000,
         "mode": "chat",
         "output_cost_per_token": 1.56e-06,
-        "source": "https://www.oracle.com/cloud/ai/generative-ai/pricing/",
+        "source": "https://www.oracle.com/artificial-intelligence/enterprise-ai/cost-estimator/",
         "supports_function_calling": true,
         "supports_response_schema": false,
         "supports_native_streaming": true
@@ -33713,7 +36018,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 1.56e-06,
-        "source": "https://www.oracle.com/cloud/ai/generative-ai/pricing/",
+        "source": "https://www.oracle.com/artificial-intelligence/enterprise-ai/cost-estimator/",
         "supports_function_calling": true,
         "supports_response_schema": false,
         "supports_native_streaming": true,
@@ -33727,7 +36032,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 1.56e-06,
-        "source": "https://www.oracle.com/cloud/ai/generative-ai/pricing/",
+        "source": "https://www.oracle.com/artificial-intelligence/enterprise-ai/cost-estimator/",
         "supports_function_calling": false,
         "supports_response_schema": false,
         "supports_native_streaming": true
@@ -33738,7 +36043,7 @@
         "max_input_tokens": 512,
         "mode": "embedding",
         "output_vector_size": 1024,
-        "source": "https://www.oracle.com/cloud/ai/generative-ai/pricing/",
+        "source": "https://www.oracle.com/artificial-intelligence/enterprise-ai/cost-estimator/",
         "supports_vision": true
     },
     "oci/cohere.command-a-reasoning-08-2025": {
@@ -34635,7 +36940,7 @@
         "max_tokens": 2048,
         "mode": "chat",
         "output_cost_per_token": 2e-07,
-        "source": "https://openrouter.ai/api/v1/models/bytedance/ui-tars-1.5-7b",
+        "source": "https://openrouter.ai/bytedance/ui-tars-1.5-7b",
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-chat": {
@@ -34870,7 +37175,7 @@
         "output_cost_per_reasoning_token": 3e-06,
         "output_cost_per_token": 3e-06,
         "rpm": 2000,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -34911,7 +37216,7 @@
         "output_cost_per_reasoning_token": 1.5e-06,
         "output_cost_per_token": 1.5e-06,
         "rpm": 2000,
-        "source": "https://ai.google.dev/pricing/gemini-3",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -35996,7 +38301,7 @@
         "max_tokens": 131000,
         "mode": "chat",
         "output_cost_per_token": 6.7e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/deepseek-r1-distill-llama-70b",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
@@ -36010,7 +38315,7 @@
         "max_tokens": 131000,
         "mode": "chat",
         "output_cost_per_token": 1e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/llama-3-1-8b-instruct",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
@@ -36023,7 +38328,7 @@
         "max_tokens": 131000,
         "mode": "chat",
         "output_cost_per_token": 6.7e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/meta-llama-3-1-70b-instruct",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_response_schema": false,
         "supports_tool_choice": false
@@ -36036,7 +38341,7 @@
         "max_tokens": 131000,
         "mode": "chat",
         "output_cost_per_token": 6.7e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/meta-llama-3-3-70b-instruct",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
@@ -36049,7 +38354,7 @@
         "max_tokens": 127000,
         "mode": "chat",
         "output_cost_per_token": 1e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/mistral-7b-instruct-v0-3",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
@@ -36062,7 +38367,7 @@
         "max_tokens": 118000,
         "mode": "chat",
         "output_cost_per_token": 1.3e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/mistral-nemo-instruct-2407",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
@@ -36075,7 +38380,7 @@
         "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 2.8e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/mistral-small-3-2-24b-instruct-2506",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
@@ -36089,7 +38394,7 @@
         "max_tokens": 32000,
         "mode": "chat",
         "output_cost_per_token": 6.3e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/mixtral-8x7b-instruct-v0-1",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_response_schema": true,
         "supports_tool_choice": false
@@ -36102,7 +38407,7 @@
         "max_tokens": 32000,
         "mode": "chat",
         "output_cost_per_token": 8.7e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/qwen2-5-coder-32b-instruct",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_response_schema": true,
         "supports_tool_choice": false
@@ -36115,7 +38420,7 @@
         "max_tokens": 32000,
         "mode": "chat",
         "output_cost_per_token": 9.1e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/qwen2-5-vl-72b-instruct",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_response_schema": true,
         "supports_tool_choice": false,
@@ -36129,7 +38434,7 @@
         "max_tokens": 32000,
         "mode": "chat",
         "output_cost_per_token": 2.3e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/qwen3-32b",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
@@ -36143,7 +38448,7 @@
         "max_tokens": 131000,
         "mode": "chat",
         "output_cost_per_token": 4e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/gpt-oss-120b",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_reasoning": true,
         "supports_response_schema": true,
@@ -36157,7 +38462,7 @@
         "max_tokens": 131000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/gpt-oss-20b",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_reasoning": true,
         "supports_response_schema": true,
@@ -36171,7 +38476,7 @@
         "max_tokens": 32000,
         "mode": "chat",
         "output_cost_per_token": 2.9e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/llava-next-mistral-7b",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_response_schema": true,
         "supports_tool_choice": false,
@@ -36185,7 +38490,7 @@
         "max_tokens": 256000,
         "mode": "chat",
         "output_cost_per_token": 1.9e-07,
-        "source": "https://endpoints.ai.cloud.ovh.net/models/mamba-codestral-7b-v0-1",
+        "source": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
         "supports_function_calling": false,
         "supports_response_schema": true,
         "supports_tool_choice": false
@@ -38321,7 +40626,7 @@
         "source": "https://docs.mistral.ai/capabilities/code_generation/"
     },
     "text-embedding-004": {
-        "deprecation_date": "2026-01-14",
+        "deprecation_date": "2027-04-01",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -38946,7 +41251,7 @@
         "max_input_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 3.6e-06,
-        "source": "https://www.together.ai/models/Qwen/Qwen3.5-397B-A17B",
+        "source": "https://www.together.ai/models/qwen3-5-397b-a17b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
@@ -41804,6 +44109,42 @@
         "supports_max_reasoning_effort": true,
         "prompt_cache_min_tokens": 512
     },
+    "vertex_ai/claude-fable-5-1": {
+        "regional_endpoint_uplift_multiplier": 1.1,
+        "supports_mid_conversation_system": true,
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_native_structured_output": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "prompt_cache_min_tokens": 512
+    },
     "vertex_ai/claude-fable-5@default": {
         "deprecation_date": "2027-06-08",
         "regional_endpoint_uplift_multiplier": 1.1,
@@ -41828,6 +44169,42 @@
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "prompt_cache_min_tokens": 512
+    },
+    "vertex_ai/claude-fable-5-1@default": {
+        "regional_endpoint_uplift_multiplier": 1.1,
+        "supports_mid_conversation_system": true,
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "vertex_ai-anthropic_models",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_native_structured_output": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -43183,7 +45560,7 @@
         "max_tokens": 2000000,
         "mode": "chat",
         "output_cost_per_token": 5e-07,
-        "source": "https://docs.x.ai/docs/models (Vertex AI Model Garden)",
+        "source": "https://docs.x.ai/developers/models",
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
@@ -43199,7 +45576,7 @@
         "max_tokens": 2000000,
         "mode": "chat",
         "output_cost_per_token": 5e-07,
-        "source": "https://docs.x.ai/docs/models (Vertex AI Model Garden)",
+        "source": "https://docs.x.ai/developers/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
@@ -43216,7 +45593,7 @@
         "max_tokens": 2000000,
         "mode": "chat",
         "output_cost_per_token": 6e-06,
-        "source": "https://docs.x.ai/docs/models (Vertex AI Model Garden)",
+        "source": "https://docs.x.ai/developers/models",
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
@@ -43232,7 +45609,7 @@
         "max_tokens": 2000000,
         "mode": "chat",
         "output_cost_per_token": 6e-06,
-        "source": "https://docs.x.ai/docs/models (Vertex AI Model Garden)",
+        "source": "https://docs.x.ai/developers/models",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
@@ -43352,7 +45729,8 @@
         "max_tokens": 1024,
         "mode": "video_generation",
         "output_cost_per_second": 0.4,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
+        "output_cost_per_second_4k": 0.6,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -43365,8 +45743,10 @@
         "max_input_tokens": 1024,
         "max_tokens": 1024,
         "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
+        "output_cost_per_second": 0.1,
+        "output_cost_per_second_1080p": 0.12,
+        "output_cost_per_second_4k": 0.3,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -43381,7 +45761,8 @@
         "max_tokens": 1024,
         "mode": "video_generation",
         "output_cost_per_second": 0.4,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
+        "output_cost_per_second_4k": 0.6,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -43395,8 +45776,10 @@
         "max_input_tokens": 1024,
         "max_tokens": 1024,
         "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
+        "output_cost_per_second": 0.1,
+        "output_cost_per_second_1080p": 0.12,
+        "output_cost_per_second_4k": 0.3,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -44100,7 +46483,8 @@
         "output_cost_per_second": 0.0001,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
-        ]
+        ],
+        "deprecation_date": "2027-02-26"
     },
     "xai/grok-3": {
         "cache_read_input_token_cost": 2e-07,
@@ -45088,7 +47472,7 @@
         "litellm_provider": "azure",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.1,
-        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "source": "https://ai.azure.com/catalog/models/sora-2",
         "supported_modalities": [
             "text"
         ],
@@ -45100,7 +47484,7 @@
         "litellm_provider": "azure",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.3,
-        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "source": "https://ai.azure.com/catalog/models/sora-2-pro",
         "supported_modalities": [
             "text"
         ],
@@ -45112,7 +47496,7 @@
         "litellm_provider": "azure",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.5,
-        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "source": "https://ai.azure.com/catalog/models/sora-2-pro",
         "supported_modalities": [
             "text"
         ],
@@ -49322,7 +51706,7 @@
         "input_cost_per_second": 0.0002833333333333333,
         "litellm_provider": "openai",
         "mode": "audio_transcription",
-        "source": "https://platform.openai.com/docs/models/gpt-realtime-whisper",
+        "source": "https://developers.openai.com/api/docs/models/gpt-realtime-whisper",
         "supported_endpoints": [
             "/v1/realtime",
             "/v1/realtime/transcription_sessions"
@@ -50574,7 +52958,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "source": "https://www.volcengine.com/docs/82379/1330310",
+        "source": "https://docs.volcengine.com/docs/82379/1330310",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": false,
@@ -50612,7 +52996,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "source": "https://www.volcengine.com/docs/82379/1330310",
+        "source": "https://docs.volcengine.com/docs/82379/1330310",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": false,
@@ -50650,7 +53034,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "source": "https://www.volcengine.com/docs/82379/1330310",
+        "source": "https://docs.volcengine.com/docs/82379/1330310",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": false,
@@ -50688,7 +53072,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
-        "source": "https://www.volcengine.com/docs/82379/1330310",
+        "source": "https://docs.volcengine.com/docs/82379/1330310",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": false,
@@ -51437,7 +53821,7 @@
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
         "supports_reasoning": true,
-        "source": "https://pinstripes.io/pricing"
+        "source": "https://pinstripes.io/"
     },
     "pinstripes/ps/qwen3.6-35b-a3b": {
         "max_tokens": 131072,
@@ -51450,7 +53834,7 @@
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
         "supports_reasoning": true,
-        "source": "https://pinstripes.io/pricing"
+        "source": "https://pinstripes.io/"
     },
     "pinstripes/ps/qwen3-30b-a3b": {
         "max_tokens": 131072,
@@ -51463,7 +53847,7 @@
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
         "supports_reasoning": true,
-        "source": "https://pinstripes.io/pricing"
+        "source": "https://pinstripes.io/"
     },
     "pinstripes/ps/qwen3-coder-30b-a3b": {
         "max_tokens": 131072,
@@ -51476,7 +53860,7 @@
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
         "supports_reasoning": false,
-        "source": "https://pinstripes.io/pricing"
+        "source": "https://pinstripes.io/"
     },
     "pinstripes/ps/deepseek-v4-flash": {
         "max_tokens": 163840,
@@ -51489,7 +53873,7 @@
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
         "supports_reasoning": true,
-        "source": "https://pinstripes.io/pricing"
+        "source": "https://pinstripes.io/"
     },
     "pinstripes/ps/minimax-m2.7": {
         "max_tokens": 1000192,
@@ -51502,7 +53886,7 @@
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
         "supports_reasoning": false,
-        "source": "https://pinstripes.io/pricing"
+        "source": "https://pinstripes.io/"
     },
     "darkbloom/gemma-4-26b": {
         "input_cost_per_token": 3e-08,
@@ -51606,7 +53990,7 @@
         "input_cost_per_second": 7.5e-05,
         "litellm_provider": "openai",
         "mode": "audio_transcription",
-        "source": "https://platform.openai.com/docs/models/gpt-transcribe",
+        "source": "https://developers.openai.com/api/docs/models/gpt-transcribe",
         "supported_endpoints": [
             "/v1/audio/transcriptions",
             "/v1/realtime/transcription_sessions"
@@ -51624,7 +54008,7 @@
         "input_cost_per_second": 0.0002833333333333333,
         "litellm_provider": "openai",
         "mode": "audio_transcription",
-        "source": "https://platform.openai.com/docs/models/gpt-live-transcribe",
+        "source": "https://developers.openai.com/api/docs/models/gpt-live-transcribe",
         "supported_endpoints": [
             "/v1/realtime",
             "/v1/realtime/transcription_sessions"
@@ -51645,7 +54029,7 @@
         "max_output_tokens": 2000,
         "max_tokens": 2000,
         "mode": "realtime",
-        "source": "https://platform.openai.com/docs/models/gpt-realtime-translate",
+        "source": "https://developers.openai.com/api/docs/models/gpt-realtime-translate",
         "supported_modalities": [
             "audio"
         ],
@@ -51673,7 +54057,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
-        "source": "https://docs.claude.com/en/docs/about-claude/models/overview",
+        "source": "https://platform.claude.com/docs/en/about-claude/models/overview",
         "supports_adaptive_thinking": true,
         "thinking_always_on": true,
         "supports_mid_conversation_system": true,
@@ -51712,7 +54096,7 @@
             "search_context_size_low": 0.01,
             "search_context_size_medium": 0.01
         },
-        "source": "https://docs.claude.com/en/docs/about-claude/models/overview",
+        "source": "https://platform.claude.com/docs/en/about-claude/models/overview",
         "supports_adaptive_thinking": true,
         "thinking_always_on": true,
         "supports_assistant_prefill": false,
@@ -52142,14 +54526,14 @@
         "supports_vision": true
     },
     "fireworks_ai/deepseek-v4-flash-0731": {
-        "cache_read_input_token_cost": 2.8e-08,
-        "input_cost_per_token": 1.4e-07,
+        "cache_read_input_token_cost": 7e-09,
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 1048576,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07,
+        "output_cost_per_token": 6.6e-07,
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -55035,5 +57419,55 @@
         "max_tokens": 40960,
         "mode": "embedding",
         "source": "https://docs.fireworks.ai/serverless/pricing"
+    },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.z.ai/guides/overview/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/Qwen/Qwen3.8-Flash": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 4.7e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "cerebras/gemma-4-31b": {
+        "input_cost_per_token": 9.9e-07,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 40960,
+        "max_tokens": 40960,
+        "mode": "chat",
+        "output_cost_per_token": 1.49e-06,
+        "source": "https://api.cerebras.ai/public/v1/models/gemma-4-31b",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "elevenlabs/scribe_v2": {
+        "input_cost_per_second": 6.11e-05,
+        "litellm_provider": "elevenlabs",
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://elevenlabs.io/pricing/api",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
     }
 }

--- a/fastllm/responses.py
+++ b/fastllm/responses.py
@@ -374,7 +374,7 @@ async def events(self:AsyncResponses, turn, finalize=None, stream=None):
         comp.message,comp.usage = Msg('assistant', texts + comp.message.content),usage
         for event in state.done_events(comp): yield event
         response = response_object(first.id, first.body, comp, first.previous.id if first.previous else None, first.created_at)
-        if finalize: await finalize(next_state, comp)
+        if finalize and (extra := await finalize(next_state, comp)): response['usage'].update(extra)
         name = 'response.incomplete' if response['status'] == 'incomplete' else 'response.completed'
         yield state.event(name, response=response)
     except asyncio.CancelledError: raise

--- a/fastllm/types.py
+++ b/fastllm/types.py
@@ -365,6 +365,7 @@ def tier_rate(meta, key, tier):
 # %% ../nbs/00_types.ipynb #8bfca02d
 @patch(as_prop=True)
 def cost(self:Completion):
+    if self.usage and 'cost' in self.usage.raw: return self.usage.raw['cost']
     meta = dict2obj(get_model_info(self.model, self.vendor_name))
     if not meta: return 0.0  # unregistered model (e.g. a custom base_url server): no pricing metadata
     api = api_registry[self.api_name]

--- a/nbs/00_types.ipynb
+++ b/nbs/00_types.ipynb
@@ -1257,6 +1257,7 @@
     "#| export\n",
     "@patch(as_prop=True)\n",
     "def cost(self:Completion):\n",
+    "    if self.usage and 'cost' in self.usage.raw: return self.usage.raw['cost']\n",
     "    meta = dict2obj(get_model_info(self.model, self.vendor_name))\n",
     "    if not meta: return 0.0  # unregistered model (e.g. a custom base_url server): no pricing metadata\n",
     "    api = api_registry[self.api_name]\n",
@@ -1270,7 +1271,7 @@
    "id": "49f58a37",
    "metadata": {},
    "source": [
-    "A model an OpenAI-compatible server invents (reached through a custom `base_url`) has no pricing metadata, so its cost is zero rather than a lookup error. The serving side owns billing in that arrangement."
+    "A model an OpenAI-compatible server invents (reached through a custom `base_url`) has no pricing metadata, so its cost is zero rather than a lookup error. The serving side owns billing in that arrangement, and when it reports a `cost` in the usage it sent, that price is the completion's cost."
    ]
   },
   {
@@ -1282,7 +1283,11 @@
    "source": [
     "unpriced = Completion(model='someserver/custom-model', message=Msg(role='assistant', content=[Text('hi')]),\n",
     "    usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15, raw=dict(input_tokens=10, output_tokens=5)), api_name='openai')\n",
-    "test_eq(unpriced.cost, 0.0)"
+    "test_eq(unpriced.cost, 0.0)\n",
+    "priced = Completion(model='someserver/custom-model', message=Msg(role='assistant', content=[Text('hi')]),\n",
+    "    usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15, raw=dict(input_tokens=10, output_tokens=5, cost=0.0123)), api_name='openai')\n",
+    "test_eq(priced.cost, 0.0123)\n",
+    "unpriced.cost, priced.cost"
    ]
   },
   {

--- a/nbs/06a_responses.ipynb
+++ b/nbs/06a_responses.ipynb
@@ -1516,7 +1516,7 @@
    "id": "f96b3aaf",
    "metadata": {},
    "source": [
-    "`events` runs the whole request. A host may start the first provider call itself and pass its `stream`, so a provider that rejects the request can be answered with a real error status before any event is sent. Each provider call streams text and client tool calls as standard events; a completion whose calls are all server tools is answered on the spot and the provider is called again, within the same public response, until a completion needs the client. A batch mixing server and client calls runs the server ones, records their results in the continuation state, and hands the client calls back. The terminal resource and the `finalize` callback see one `Completion`: every step's text in order, and the usage of every provider call summed. `finalize` receives the next state and that `Completion` before the terminal event is emitted, so a host can persist and bill before the client learns the response is complete.\n"
+    "`events` runs the whole request. A host may start the first provider call itself and pass its `stream`, so a provider that rejects the request can be answered with a real error status before any event is sent. Each provider call streams text and client tool calls as standard events; a completion whose calls are all server tools is answered on the spot and the provider is called again, within the same public response, until a completion needs the client. A batch mixing server and client calls runs the server ones, records their results in the continuation state, and hands the client calls back. The terminal resource and the `finalize` callback see one `Completion`: every step's text in order, and the usage of every provider call summed. `finalize` receives the next state and that `Completion` before the terminal event is emitted, so a host can persist and bill before the client learns the response is complete. Usage fields it returns, such as the price it charged, are merged into the terminal frame's usage, since only the host knows them.\n"
    ]
   },
   {
@@ -1552,7 +1552,7 @@
     "        comp.message,comp.usage = Msg('assistant', texts + comp.message.content),usage\n",
     "        for event in state.done_events(comp): yield event\n",
     "        response = response_object(first.id, first.body, comp, first.previous.id if first.previous else None, first.created_at)\n",
-    "        if finalize: await finalize(next_state, comp)\n",
+    "        if finalize and (extra := await finalize(next_state, comp)): response['usage'].update(extra)\n",
     "        name = 'response.incomplete' if response['status'] == 'incomplete' else 'response.completed'\n",
     "        yield state.event(name, response=response)\n",
     "    except asyncio.CancelledError: raise\n",
@@ -1830,14 +1830,35 @@
    "outputs": [],
    "source": [
     "lookup_final = []\n",
-    "async def capture_lookup(state, comp): lookup_final.append((state, comp))\n",
+    "async def capture_lookup(state, comp):\n",
+    "    lookup_final.append((state, comp))\n",
+    "    return dict(cost=0.0123)\n",
     "lookup_body = dict(model='openai/gpt-5.6-luna', input=\"What does 'gorp' mean according to the glossary? Use lookup, then answer in one sentence.\", tools=[])\n",
     "lookup_frames = [frame async for frame in responses.events(responses.prepare(lookup_body, server_tools=[lookup]), finalize=capture_lookup)]\n",
     "lookup_state,lookup_comp = lookup_final[0]\n",
+    "lookup_comp.message.text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c03a6c",
+   "metadata": {},
+   "source": [
+    "The finalizer saw one completion whose history holds the server round, no function call reached the client, and the terminal frame's usage carries the price the finalizer returned:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "336e8265",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "test_eq([m.role for m in lookup_state.history], ['user', 'assistant', 'tool', 'assistant'])\n",
     "assert 'function_call' not in ''.join(lookup_frames)\n",
+    "assert '\"cost\":0.0123' in lookup_frames[-1]\n",
     "assert 'trail mix' in lookup_comp.message.text.lower(), lookup_comp.message.text\n",
-    "lookup_comp.message.text, lookup_comp.usage.prompt_tokens"
+    "lookup_frames[-1]"
    ]
   },
   {


### PR DESCRIPTION
`AsyncResponses.events` merges whatever `finalize` returns into the usage of the `response.completed` frame, so a host can report fields only it knows, such as the price it charged. `Completion.cost` returns the `cost` a server put in the usage before pricing from the model map, so a client of such a host displays what was billed rather than its own estimate. The `lookup` lesson in the Responses notebook shows the price arriving in the terminal frame, and the unpriced-model lesson in `00_types` shows both cost paths.

https://claude.ai/code/session_01B2cL4HsnyJJ7G5ZgCmg2BW