### PR TITLE
Charge provider-run web searches per query

### DIFF
--- a/fastllm/anthropic.py
+++ b/fastllm/anthropic.py
@@ -44,7 +44,8 @@ def norm_usage(resp):
     pt = int(usg.get("input_tokens", 0) or 0) + cached + cache_creation
     ct = int(usg.get("output_tokens", 0) or 0)
     return Usage(prompt_tokens=pt, completion_tokens=ct, total_tokens=pt + ct,
-                 cached_tokens=cached, cache_creation_tokens=cache_creation, reasoning_tokens=0, raw=usg)
+                 cached_tokens=cached, cache_creation_tokens=cache_creation, reasoning_tokens=0, raw=usg,
+                 search_queries=int(nested_idx(usg, 'server_tool_use', 'web_search_requests') or 0))
 
 def finalize_usage(usg, parts):
     "Split reasoning tokens out of `output_tokens`: the reported `thinking_tokens`, else an estimate from the thinking text."
@@ -53,7 +54,7 @@ def finalize_usage(usg, parts):
     ct = int(usg.raw.get('output_tokens', usg.completion_tokens) or 0)
     rt = int(nested_idx(usg.raw, 'output_tokens_details', 'thinking_tokens') or 0) or (min(int(len(rc.split())*1.5), ct) if rc else 0)
     return Usage(prompt_tokens=usg.prompt_tokens, completion_tokens=ct-rt, total_tokens=usg.prompt_tokens+ct,
-        cached_tokens=usg.cached_tokens, cache_creation_tokens=usg.cache_creation_tokens, reasoning_tokens=rt, raw=usg.raw)
+        cached_tokens=usg.cached_tokens, cache_creation_tokens=usg.cache_creation_tokens, reasoning_tokens=rt, search_queries=usg.search_queries, raw=usg.raw)
 
 # %% ../nbs/04_anthropic.ipynb #7a8b1f8f
 def norm_finish(resp, tcs=None):

--- a/fastllm/gemini.py
+++ b/fastllm/gemini.py
@@ -67,7 +67,7 @@ def norm_usage(resp):
     if call := grounding(cand)[1]: stu['google_search'] = len(call.arguments['queries'] or [1])
     if stu: usg['server_tool_use'] = stu
     return Usage(prompt_tokens=pt, completion_tokens=ct, total_tokens=tt,
-                 cached_tokens=cached, reasoning_tokens=reasoning, raw=usg)
+                 cached_tokens=cached, reasoning_tokens=reasoning, search_queries=stu.get('google_search', 0), raw=usg)
 
 # %% ../nbs/05_gemini.ipynb #7a8b1f8f
 def norm_finish(resp, tcs=None):

--- a/fastllm/openai_responses.py
+++ b/fastllm/openai_responses.py
@@ -53,8 +53,7 @@ def norm_usage(resp):
     server_tool_use = dict(Counter(o['type'] for o in resp.get('output', []) if o.get('type') != 'function_call' and o.get('type', '').endswith('_call')))
     if server_tool_use: usg['server_tool_use'] = server_tool_use
     return Usage(prompt_tokens=pt, completion_tokens=ct, total_tokens=tt,
-        cached_tokens=cached, reasoning_tokens=reasoning, raw=usg)
-
+        cached_tokens=cached, reasoning_tokens=reasoning, search_queries=server_tool_use.get('web_search_call', 0), raw=usg)
 
 # %% ../nbs/02_oai_responses.ipynb #95102df4
 def norm_finish(resp, tcs=None):

--- a/fastllm/types.py
+++ b/fastllm/types.py
@@ -26,16 +26,15 @@ from aidialog.msg_parts import Msg, Thinking, ToolUse, Completion, StopResponse,
 class Usage(BasicRepr):
     "Normalized usage."
     def __init__(self, prompt_tokens=0, completion_tokens=0, total_tokens=0, cached_tokens=0,
-        cache_creation_tokens=0, reasoning_tokens=0, raw=None):
+        cache_creation_tokens=0, reasoning_tokens=0, search_queries=0, raw=None):
         if raw is None: raw = {}
         store_attr()
     def __eq__(self, o): return type(o) is type(self) and self.__dict__ == o.__dict__
 
-
 # %% ../nbs/00_types.ipynb #bae1c130
 @patch
 def __add__(self:Usage, o):
-    fields = 'prompt_tokens completion_tokens total_tokens cached_tokens cache_creation_tokens reasoning_tokens'.split()
+    fields = 'prompt_tokens completion_tokens total_tokens cached_tokens cache_creation_tokens reasoning_tokens search_queries'.split()
     return Usage(**{k: getattr(self, k)+getattr(o, k) for k in fields}, raw=o.raw)
 
 # %% ../nbs/00_types.ipynb #4901e693
@@ -366,4 +365,5 @@ def cost(self:Completion):
     api = api_registry[self.api_name]
     if not hasattr(api, 'cost'): raise NotImplementedError(f"API: {self.api_name} doesn't have a registered `cost` function in ns")
     res = api.cost(self.usage, meta)
+    if (n := self.usage.search_queries) and (rates := meta.get('search_context_cost_per_query')): res += n * rates['search_context_size_medium']
     return res*2 if self.vendor_name=='deepseek' and self.model.startswith('deepseek-v4') and is_deepseek_peak_hour() else res

--- a/nbs/00_types.ipynb
+++ b/nbs/00_types.ipynb
@@ -95,6 +95,7 @@
     "| `prompt_tokens` | `input_tokens` | `prompt_tokens` | `input_tokens` | `promptTokenCount` |\n",
     "| `completion_tokens` | `output_tokens` | `completion_tokens` | `output_tokens` | `candidatesTokenCount` |\n",
     "| `total_tokens` | `total_tokens` | `total_tokens` | (computed: in + out) | `totalTokenCount` |\n",
+    "| `search_queries` | `web_search_call` items | (none) | `server_tool_use.web_search_requests` | `groundingMetadata.webSearchQueries` |\n",
     "\n",
     "**`Usage.raw` preserves the full provider payload** — advanced accounting fields (caching, reasoning, tool use tokens) vary too much across providers to normalize, so downstream code like `estimate_cost` extracts them from `raw` with best-effort multi-key lookups (e.g. `_cached_prompt_tokens` tries `cached_input_tokens`, `cache_read_input_tokens`, `prompt_tokens_details.cached_tokens`)."
    ]
@@ -110,10 +111,10 @@
     "class Usage(BasicRepr):\n",
     "    \"Normalized usage.\"\n",
     "    def __init__(self, prompt_tokens=0, completion_tokens=0, total_tokens=0, cached_tokens=0,\n",
-    "        cache_creation_tokens=0, reasoning_tokens=0, raw=None):\n",
+    "        cache_creation_tokens=0, reasoning_tokens=0, search_queries=0, raw=None):\n",
     "        if raw is None: raw = {}\n",
     "        store_attr()\n",
-    "    def __eq__(self, o): return type(o) is type(self) and self.__dict__ == o.__dict__\n"
+    "    def __eq__(self, o): return type(o) is type(self) and self.__dict__ == o.__dict__"
    ]
   },
   {
@@ -134,7 +135,7 @@
     "#| export\n",
     "@patch\n",
     "def __add__(self:Usage, o):\n",
-    "    fields = 'prompt_tokens completion_tokens total_tokens cached_tokens cache_creation_tokens reasoning_tokens'.split()\n",
+    "    fields = 'prompt_tokens completion_tokens total_tokens cached_tokens cache_creation_tokens reasoning_tokens search_queries'.split()\n",
     "    return Usage(**{k: getattr(self, k)+getattr(o, k) for k in fields}, raw=o.raw)"
    ]
   },
@@ -1277,6 +1278,7 @@
     "    api = api_registry[self.api_name]\n",
     "    if not hasattr(api, 'cost'): raise NotImplementedError(f\"API: {self.api_name} doesn't have a registered `cost` function in ns\")\n",
     "    res = api.cost(self.usage, meta)\n",
+    "    if (n := self.usage.search_queries) and (rates := meta.get('search_context_cost_per_query')): res += n * rates['search_context_size_medium']\n",
     "    return res*2 if self.vendor_name=='deepseek' and self.model.startswith('deepseek-v4') and is_deepseek_peak_hour() else res"
    ]
   },

--- a/nbs/02_oai_responses.ipynb
+++ b/nbs/02_oai_responses.ipynb
@@ -349,7 +349,7 @@
     "    server_tool_use = dict(Counter(o['type'] for o in resp.get('output', []) if o.get('type') != 'function_call' and o.get('type', '').endswith('_call')))\n",
     "    if server_tool_use: usg['server_tool_use'] = server_tool_use\n",
     "    return Usage(prompt_tokens=pt, completion_tokens=ct, total_tokens=tt,\n",
-    "        cached_tokens=cached, reasoning_tokens=reasoning, raw=usg)\n"
+    "        cached_tokens=cached, reasoning_tokens=reasoning, search_queries=server_tool_use.get('web_search_call', 0), raw=usg)"
    ]
   },
   {
@@ -761,6 +761,7 @@
    "source": [
     "test_eq(c.tool_calls[0].server, True)\n",
     "test_eq(c.finish_reason, 'stop')\n",
+    "test_eq(c.usage.search_queries, 1)\n",
     "assert ': http' in c.tool_calls[0].text, c.tool_calls[0].text\n",
     "c.tool_calls[0].text"
    ]
@@ -2889,6 +2890,26 @@
     "    cost=cost, get_hdrs=get_hdrs, fix_payload=fix_payload,\n",
     "    endpoint='/responses')\n",
     "api_registry.register('openai', **api_ns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ff2e0b2",
+   "metadata": {},
+   "source": [
+    "A search the provider ran is charged per query on top of the tokens, at the model's `search_context_cost_per_query` rate for a medium context size (the size the price map lists, and every model here prices all sizes alike). Every transport counts those queries into `Usage.search_queries`, so `Completion.cost` adds the charge with no provider-specific code, over this transport's token-only `cost`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0c1e62a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokens_only = cost(c.usage, get_model_info(mn, vnd_nm))\n",
+    "test_close(c.cost - tokens_only, c.usage.search_queries * 0.01)\n",
+    "c.usage.search_queries, tokens_only, c.cost"
    ]
   },
   {

--- a/nbs/04_anthropic.ipynb
+++ b/nbs/04_anthropic.ipynb
@@ -321,7 +321,8 @@
     "    pt = int(usg.get(\"input_tokens\", 0) or 0) + cached + cache_creation\n",
     "    ct = int(usg.get(\"output_tokens\", 0) or 0)\n",
     "    return Usage(prompt_tokens=pt, completion_tokens=ct, total_tokens=pt + ct,\n",
-    "                 cached_tokens=cached, cache_creation_tokens=cache_creation, reasoning_tokens=0, raw=usg)\n",
+    "                 cached_tokens=cached, cache_creation_tokens=cache_creation, reasoning_tokens=0, raw=usg,\n",
+    "                 search_queries=int(nested_idx(usg, 'server_tool_use', 'web_search_requests') or 0))\n",
     "\n",
     "def finalize_usage(usg, parts):\n",
     "    \"Split reasoning tokens out of `output_tokens`: the reported `thinking_tokens`, else an estimate from the thinking text.\"\n",
@@ -330,7 +331,7 @@
     "    ct = int(usg.raw.get('output_tokens', usg.completion_tokens) or 0)\n",
     "    rt = int(nested_idx(usg.raw, 'output_tokens_details', 'thinking_tokens') or 0) or (min(int(len(rc.split())*1.5), ct) if rc else 0)\n",
     "    return Usage(prompt_tokens=usg.prompt_tokens, completion_tokens=ct-rt, total_tokens=usg.prompt_tokens+ct,\n",
-    "        cached_tokens=usg.cached_tokens, cache_creation_tokens=usg.cache_creation_tokens, reasoning_tokens=rt, raw=usg.raw)"
+    "        cached_tokens=usg.cached_tokens, cache_creation_tokens=usg.cache_creation_tokens, reasoning_tokens=rt, search_queries=usg.search_queries, raw=usg.raw)"
    ]
   },
   {
@@ -836,6 +837,7 @@
    "source": [
     "resp = await ant_call(model=mn, max_tokens=mt, messages=[{\"role\": \"user\", \"content\": \"Use web search to get the weather in Istanbul\"}], tools=[{\"type\": \"web_search_20250305\", \"name\": \"web_search\"}])\n",
     "comp = mk_completion(resp, mn, api_name, vnd_nm)\n",
+    "assert comp.usage.search_queries >= 1, comp.usage\n",
     "comp"
    ]
   },

--- a/nbs/05_gemini.ipynb
+++ b/nbs/05_gemini.ipynb
@@ -568,7 +568,7 @@
     "    if call := grounding(cand)[1]: stu['google_search'] = len(call.arguments['queries'] or [1])\n",
     "    if stu: usg['server_tool_use'] = stu\n",
     "    return Usage(prompt_tokens=pt, completion_tokens=ct, total_tokens=tt,\n",
-    "                 cached_tokens=cached, reasoning_tokens=reasoning, raw=usg)"
+    "                 cached_tokens=cached, reasoning_tokens=reasoning, search_queries=stu.get('google_search', 0), raw=usg)"
    ]
   },
   {
@@ -1049,7 +1049,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_eq(comp.usage.raw['server_tool_use']['google_search'], len(comp.tool_calls[0].arguments['queries']))\n"
+    "test_eq(comp.usage.search_queries, len(comp.tool_calls[0].arguments['queries']))\n"
    ]
   },
   {


### PR DESCRIPTION
`Usage` gains a `search_queries` count, filled by every transport (Anthropic's `server_tool_use.web_search_requests`, Gemini's `webSearchQueries`, OpenAI's `web_search_call` items) and summed across a turn. `Completion.cost` adds those queries at the model's `search_context_cost_per_query` rate, so a hosted search is billed on top of its tokens for every provider. See the search lesson in the OpenAI Responses notebook for the charge over the transport's token-only `cost`.