### PR TITLE
Use stateless Chat Completions for Meta models

### DIFF
--- a/fastllm/acomplete.py
+++ b/fastllm/acomplete.py
@@ -39,7 +39,7 @@ vendor_mapping = {
     "fireworks_ai": ('openai_chat', "https://api.fireworks.ai/inference/v1", "FIREWORKS_API_KEY"),
     "qwen":         ('openai_chat', "https://dashscope.aliyuncs.com/compatible-mode/v1", "QWEN_API_KEY"),
     "minimax":      ('anthropic', "https://api.minimax.io/anthropic", "MINIMAX_API_KEY"),
-    "meta":         ('openai', "https://api.meta.ai/v1", "META_API_KEY"),
+    "meta":         ('openai_chat', "https://api.meta.ai/v1", "META_API_KEY"),
     "zai":          ('openai_chat', "https://api.z.ai/api/paas/v4", "ZAI_API_KEY")}
 
 # %% ../nbs/06_acomplete.ipynb #e3ed40fb

--- a/nbs/06_acomplete.ipynb
+++ b/nbs/06_acomplete.ipynb
@@ -171,7 +171,7 @@
     "    \"fireworks_ai\": ('openai_chat', \"https://api.fireworks.ai/inference/v1\", \"FIREWORKS_API_KEY\"),\n",
     "    \"qwen\":         ('openai_chat', \"https://dashscope.aliyuncs.com/compatible-mode/v1\", \"QWEN_API_KEY\"),\n",
     "    \"minimax\":      ('anthropic', \"https://api.minimax.io/anthropic\", \"MINIMAX_API_KEY\"),\n",
-    "    \"meta\":         ('openai', \"https://api.meta.ai/v1\", \"META_API_KEY\"),\n",
+    "    \"meta\":         ('openai_chat', \"https://api.meta.ai/v1\", \"META_API_KEY\"),\n",
     "    \"zai\":          ('openai_chat', \"https://api.z.ai/api/paas/v4\", \"ZAI_API_KEY\")}"
    ]
   },
@@ -485,6 +485,25 @@
     "test_eq(cli.base_url, 'https://api.fireworks.ai/inference/v1')\n",
     "test_eq(api_name, 'openai_chat')\n",
     "test_eq(vendor_name, 'fireworks_ai')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4abe986",
+   "metadata": {},
+   "source": [
+    "Meta serves both Chat Completions and the Responses format at one base URL. Its stored responses can expire partway through a tool loop, so the vendor runs on the stateless chat transport, which replays history itself:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "062d5445",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cli, api_name, vendor_name = mk_client('meta/muse-spark-1.3')\n",
+    "test_eq((cli.base_url, api_name, vendor_name), ('https://api.meta.ai/v1', 'openai_chat', 'meta'))"
    ]
   },
   {


### PR DESCRIPTION
Meta models use the `openai_chat` transport to avoid stored-response expiry during tool loops. The `acomplete` notebook demonstrates the vendor selection.